### PR TITLE
Remove emin=1-emax restriction and specify emin explicitly

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -42,7 +42,7 @@ CFLAGS=$(WFLAGS) $(ARCHFLAGS) -std=gnu99 -I $(SRCDIR) \
 COPTIM=-O3
 CCOVFLAGS=-Og -g --coverage
 CLIBS=-lm -fopenmp
-CHECKLIBS=-lcheck -lpthread -lsubunit -lrt
+CHECKLIBS=-lcheck -lpthread -lsubunit
 PCG_INCLUDE=-include $(PCG_HEADER)
 PCG_LIB=-L $(DEPSDIR)pcg-c/src -lpcg_random
 PCG_FLAGS=$(PCG_INCLUDE) $(PCG_LIB)

--- a/Makefile
+++ b/Makefile
@@ -38,7 +38,7 @@ OCTAVE:=octave
 WFLAGS=-Wall -Wextra -pedantic
 ARCHFLAGS=-march=native
 CFLAGS=$(WFLAGS) $(ARCHFLAGS) -std=gnu99 -I $(SRCDIR) \
-	-I /usr/local/include -L /usr/local/lib
+	-I $(PREFIX)include -L $(PREFIX)lib
 COPTIM=-O3
 CCOVFLAGS=-Og -g --coverage
 CLIBS=-lm -fopenmp

--- a/Makefile
+++ b/Makefile
@@ -105,7 +105,8 @@ $(BUILDDIR)cpfloat.tmp: $(SRCDIR)cpfloat_binary32.h $(SRCDIR)cpfloat_binary64.h
 		$(SRCDIR)cpfloat_binary32.h > $(BUILDDIR)cpfloat.tmp
 	sed '/CPFLOAT_BINARY\|^#include "cpfloat_\(doc\|def\)/d' \
 		$(SRCDIR)cpfloat_binary64.h >> $(BUILDDIR)cpfloat.tmp
-	sed -i '' 's/static inline //g' $(BUILDDIR)cpfloat.tmp
+	sed 's/static inline //g' $(BUILDDIR)cpfloat.tmp > $(BUILDDIR)cpfloat.tmpfinal
+	$(MV) $(BUILDDIR)cpfloat.tmpfinal $(BUILDDIR)cpfloat.tmp
 
 $(BUILDDIR)cpfloat_template.c: $(SRCDIR)cpfloat_template.h
 	sed 's/static inline//g' $< > $@
@@ -117,7 +118,8 @@ $(BUILDDIR)cpfloat.c: $(BUILDDIR)cpfloat.tmp $(BUILDDIR)cpfloat_template.c
 
 $(INCDIR)cpfloat.h: $(BUILDDIR)cpfloat.tmp $(BUILDDIR) $(INCDIR)
 	sed '/^\/\*\* @/,/^\/\*\* @/d' $< > $(BUILDDIR)cpfloat-h.tmp
-	sed -i '' '/^ \*\|\/\*/d' $(BUILDDIR)cpfloat-h.tmp
+	sed '/^ \*\|\/\*/d' $(BUILDDIR)cpfloat-h.tmp >  $(BUILDDIR)cpfloat-h.tmpfinal
+	$(MV)  $(BUILDDIR)cpfloat-h.tmpfinal $(BUILDDIR)cpfloat-h.tmp
 	printf "/* SPDX-FileCopyrightText: 2020 Massimiliano Fasi and Mantas Mikaitis */\n\
 	/* SPDX-License-Identifier: LGPL-2.1-or-later                         */\n\
 	\n\
@@ -215,7 +217,8 @@ ctest: $(BINDIR)cpfloat_test
 
 $(TESTDIR)libcpfloat_test.c: $(TESTDIR)cpfloat_test.c
 	sed '/#include "cpfloat_binary32.h"/d' $< > $@
-	sed -i '' 's/#include "cpfloat_binary64.h"/#include "cpfloat.h"/g' $@
+	sed 's/#include "cpfloat_binary64.h"/#include "cpfloat.h"/g' $@ > cpfloath.temp
+	$(MV) cpfloath.temp $@
 
 $(BINDIR)libcpfloat_static_test: $(TESTDIR)libcpfloat_test.c lib
 	$(CC) $(CFLAGS) $(COPTIM) -fsanitize=undefined -static -o $@ $< \

--- a/Makefile
+++ b/Makefile
@@ -105,7 +105,7 @@ $(BUILDDIR)cpfloat.tmp: $(SRCDIR)cpfloat_binary32.h $(SRCDIR)cpfloat_binary64.h
 		$(SRCDIR)cpfloat_binary32.h > $(BUILDDIR)cpfloat.tmp
 	sed '/CPFLOAT_BINARY\|^#include "cpfloat_\(doc\|def\)/d' \
 		$(SRCDIR)cpfloat_binary64.h >> $(BUILDDIR)cpfloat.tmp
-	sed -i 's/static inline //g' $(BUILDDIR)cpfloat.tmp
+	sed -i '' 's/static inline //g' $(BUILDDIR)cpfloat.tmp
 
 $(BUILDDIR)cpfloat_template.c: $(SRCDIR)cpfloat_template.h
 	sed 's/static inline//g' $< > $@
@@ -117,7 +117,7 @@ $(BUILDDIR)cpfloat.c: $(BUILDDIR)cpfloat.tmp $(BUILDDIR)cpfloat_template.c
 
 $(INCDIR)cpfloat.h: $(BUILDDIR)cpfloat.tmp $(BUILDDIR) $(INCDIR)
 	sed '/^\/\*\* @/,/^\/\*\* @/d' $< > $(BUILDDIR)cpfloat-h.tmp
-	sed -i '/^ \*\|\/\*/d' $(BUILDDIR)cpfloat-h.tmp
+	sed -i '' '/^ \*\|\/\*/d' $(BUILDDIR)cpfloat-h.tmp
 	printf "/* SPDX-FileCopyrightText: 2020 Massimiliano Fasi and Mantas Mikaitis */\n\
 	/* SPDX-License-Identifier: LGPL-2.1-or-later                         */\n\
 	\n\
@@ -215,7 +215,7 @@ ctest: $(BINDIR)cpfloat_test
 
 $(TESTDIR)libcpfloat_test.c: $(TESTDIR)cpfloat_test.c
 	sed '/#include "cpfloat_binary32.h"/d' $< > $@
-	sed -i 's/#include "cpfloat_binary64.h"/#include "cpfloat.h"/g' $@
+	sed -i '' 's/#include "cpfloat_binary64.h"/#include "cpfloat.h"/g' $@
 
 $(BINDIR)libcpfloat_static_test: $(TESTDIR)libcpfloat_test.c lib
 	$(CC) $(CFLAGS) $(COPTIM) -fsanitize=undefined -static -o $@ $< \

--- a/README.md
+++ b/README.md
@@ -5,25 +5,29 @@
 
 # CPFloat: Custom-Precision Floating-Point numbers
 
-CPFloat is a C library for simulating low-precision floating-point arithmetics. CPFloat provides efficient routines for rounding, performing arithmetic operations, evaluating  mathematical functions, and querying properties of the simulated low-precision format. Internally, numbers are stored in `float` or `double` arrays. The low-precision format (target format) follows a straightforward extension of the IEEE 754 standard and it is entirely specified by three parameters:
+CPFloat is a C library for simulating low-precision floating-point arithmetics. CPFloat provides efficient routines for rounding, performing arithmetic operations, evaluating  mathematical functions, and querying properties of the simulated low-precision format. Internally, numbers are stored in `float` or `double` arrays. The low-precision format (target format) follows an extension of the IEEE 754 standard and it is entirely specified by four parameters:
 * a positive integer *p*, which represents the number of digits of precision;
-* a positive integer *e*<sub>max</sub>, which represents the maximum supported exponent; and
+* a positive integer *e*<sub>max</sub>, which represents the maximum supported exponent;
+* a positive integer *e*<sub>min</sub>, which represents the minimum supported exponent; and
 * a Boolean variable σ, set to **true** if subnormal are supported and to **false** otherwise.
 
-The largest values of *p* and *e*<sub>max</sub> that can be used depend on the format in which the converted numbers are to be stored (storage format). A more extensive description of the characteristics of the low-precision formats that can be used, together with more details on the choice of the admissible values of *p*, *e*<sub>max</sub>, and *σ* can be found in [[1]](#ref1).
+The largest values of *p* and *e*<sub>max</sub>, and the smallest value of *e*<sub>min</sub> that can be used depend on the format in which the converted numbers are to be stored (storage format). A more extensive description of the characteristics of the low-precision formats that can be used, together with more details on the choice of the admissible values of *p*, *e*<sub>max</sub>, and *σ* can be found in [[1]](#ref1).
 
 The library was originally intended as a faster version of the MATLAB function `chop` [[2]](#ref2), which is [available on GitHub](https://github.com/higham/chop).
+The latest versions of the library have a variety of subtle differences compared with `chop`.
 
-The code to reproduce the results of the tests in [[1]](#ref1) are [available on GitHub](https://github.com/north-numerical-computing/cpfloat_experiments).
+The code to reproduce the results of the tests in [[1]](#ref1) is [available on GitHub](https://github.com/north-numerical-computing/cpfloat_experiments).
 
 
 # Dependencies
 
 The only (optional) dependency of CPFloat is the [C implementation](https://github.com/imneme/pcg-c) of the [PCG Library](https://www.pcg-random.org), which provides a variety of high-quality pseudo-random number generators. For an in-depth discussion of the algorithms underlying the PCG Library, we recommend the [paper](https://www.pcg-random.org/paper.html) by [Melissa O'Neill](https://www.cs.hmc.edu/~oneill) [[3]](#ref3). If the header file `pcg_variants.h` in `include/pcg-c/include/pcg_variants.h` is not included at compile-time with the `--include` option, then CPFloat relies on the default C pseudo-random number generator.
 
-The PCG Library is free software (see the [Licensing information](#licensing-information) below), and its generators are more efficient, reliable, and flexible than any combination of the functions `srand`, `rand`, and `rand_r` from the C standard library. We see no reason not to use it, and a warning is issued at compile time if the location of `pcg_variant.h` is not specified correctly.
+The PCG Library is free software (see the [Licensing information](#licensing-information) below), and its generators are more efficient, reliable, and flexible than any combination of the functions `srand`, `rand`, and `rand_r` from the C standard  library. A warning is issued at compile time if the location of `pcg_variant.h` is not specified correctly.
 
-Compiling the MEX interface requires a reasonably recent version of MATLAB or Octave, and testing the interface requires the function `float_params`, which is [available on GitHub](https://github.com/higham/float_params). The unit tests for the C implementation in `test/cpfloat_test.ts` require the [check unit testing framework for C](https://libcheck.github.io/check).
+# Developer dependencies
+
+Compiling the MEX interface requires a reasonably recent version of MATLAB or Octave, and testing the interface requires the function `float_params`, which is [available on GitHub](https://github.com/higham/float_params). The unit tests for the C implementation in `test/cpfloat_test.ts` require the [check unit testing framework for C](https://libcheck.github.io/check) and the [subunit protocol](https://github.com/testing-cabal/subunit).
 
 # Installation
 

--- a/README.md
+++ b/README.md
@@ -7,14 +7,17 @@
 
 CPFloat is a C library for simulating low-precision floating-point arithmetics. CPFloat provides efficient routines for rounding, performing arithmetic operations, evaluating  mathematical functions, and querying properties of the simulated low-precision format. Internally, numbers are stored in `float` or `double` arrays. The low-precision format (target format) follows an extension of the IEEE 754 standard and it is entirely specified by four parameters:
 * a positive integer *p*, which represents the number of digits of precision;
-* a positive integer *e*<sub>max</sub>, which represents the maximum supported exponent;
-* a positive integer *e*<sub>min</sub>, which represents the minimum supported exponent; and
+* a positive integer *e*<sub>min</sub>, which represents the minimum supported exponent;
+* a positive integer *e*<sub>max</sub>, which represents the maximum supported exponent; and
 * a Boolean variable σ, set to **true** if subnormal are supported and to **false** otherwise.
 
-The largest values of *p* and *e*<sub>max</sub>, and the smallest value of *e*<sub>min</sub> that can be used depend on the format in which the converted numbers are to be stored (storage format). A more extensive description of the characteristics of the low-precision formats that can be used, together with more details on the choice of the admissible values of *p*, *e*<sub>max</sub>, and *σ* can be found in [[1]](#ref1).
+Valid choices of *p*, *e*<sub>min</sub>, and *e*<sub>max</sub> depend on the format in which the converted numbers are to be stored (storage format). A more extensive description of the characteristics of the low-precision formats that can be used, together with more details on admissible values for *p*, *e*<sub>min</sub>, *e*<sub>max</sub>, and *σ* can be found in [[1]](#ref1).
 
 The library was originally intended as a faster version of the MATLAB function `chop` [[2]](#ref2), which is [available on GitHub](https://github.com/higham/chop).
-The latest versions of the library have a variety of subtle differences compared with `chop`.
+The latest versions of the library have a variety of subtle differences compared with `chop`:
+* since June 14, 2022 `chop` supports specifying the function for generating random numbers. The MEX interface of CPFloat does not offer this capability;
+* since v0.6.0 CPFloat allows to specify *e*<sub>min</sub> and *e*<sub>max</sub> instead of the previous strategy of specifying *e*<sub>max</sub> and enforcing *e*<sub>min</sub>=1-*e*<sub>max</sub>;
+* since v0.6.0 the default 8-bit format E4M3 has *e*<sub>max</sub>=8 (in `chop` it is set to 7).
 
 The code to reproduce the results of the tests in [[1]](#ref1) is [available on GitHub](https://github.com/north-numerical-computing/cpfloat_experiments).
 
@@ -23,11 +26,13 @@ The code to reproduce the results of the tests in [[1]](#ref1) is [available on 
 
 The only (optional) dependency of CPFloat is the [C implementation](https://github.com/imneme/pcg-c) of the [PCG Library](https://www.pcg-random.org), which provides a variety of high-quality pseudo-random number generators. For an in-depth discussion of the algorithms underlying the PCG Library, we recommend the [paper](https://www.pcg-random.org/paper.html) by [Melissa O'Neill](https://www.cs.hmc.edu/~oneill) [[3]](#ref3). If the header file `pcg_variants.h` in `include/pcg-c/include/pcg_variants.h` is not included at compile-time with the `--include` option, then CPFloat relies on the default C pseudo-random number generator.
 
-The PCG Library is free software (see the [Licensing information](#licensing-information) below), and its generators are more efficient, reliable, and flexible than any combination of the functions `srand`, `rand`, and `rand_r` from the C standard  library. A warning is issued at compile time if the location of `pcg_variant.h` is not specified correctly.
+The PCG Library is free software (see the [Licensing information](#licensing-information) below), and its generators are more efficient, reliable, and flexible than any combination of the functions `srand`, `rand`, and `rand_r` from the C standard library. A warning is issued at compile time if the location of `pcg_variant.h` is not specified correctly.
+
+Compiling the MEX interface requires a reasonably recent version of MATLAB or Octave.
 
 # Developer dependencies
 
-Compiling the MEX interface requires a reasonably recent version of MATLAB or Octave, and testing the interface requires the function `float_params`, which is [available on GitHub](https://github.com/higham/float_params). The unit tests for the C implementation in `test/cpfloat_test.ts` require the [check unit testing framework for C](https://libcheck.github.io/check) and the [subunit protocol](https://github.com/testing-cabal/subunit).
+Testing the MEX interface requires the function `float_params`, which is [available on GitHub](https://github.com/higham/float_params). The unit tests for the C implementation in `test/cpfloat_test.ts` require the [check unit testing framework for C](https://libcheck.github.io/check) and the [subunit protocol](https://github.com/testing-cabal/subunit).
 
 # Installation
 
@@ -56,7 +61,7 @@ make mexoct # Compile MEX interface for Octave.
 ```
 These two commands compile and autotune the MEX interface in MATLAB and Octave, respectively, by using the functions `mex/cpfloat_compile.m` and `mex/cpfloat_autotune.m`. To use the interface, the `bin/` folder must be in MATLAB's search path.
 
-On a system where the `make` build automation tool is not available, we recommend building the MEX interface by running the script `cpfloat_compile_nomake.m` in the `mex/` folder. The script attempts to compile and auto-tune the MEX interface using the default C compiler. The following code will download the repository as a ZIP file, inflate it, and try to compile it:
+On a system where the `make` build automation tool is not available, we recommend building the MEX interface by running the script `cpfloat_compile_nomake.m` in the `mex/` folder. The script attempts to compile and autotune the MEX interface using the default C compiler. The following code will download the repository as a ZIP file, inflate it, and try to compile it:
 
 ```matlab
 zip_url = 'https://codeload.github.com/north-numerical-computing/cpfloat/zip/refs/heads/main';

--- a/README.md
+++ b/README.md
@@ -126,7 +126,7 @@ These two commands run, in MATLAB and Octave respectively, the function `test/cp
 
 # Acknowledgements
 
-The library was written by Massimiliano Fasi and Mantas Mikaitis. We thank Ian McInerney and Theo Mary for testing the library and suggesting improvements.
+The library was written by Massimiliano Fasi and Mantas Mikaitis. We thank Theo Mary, Ian McInerney, and Siegfried Rump for testing the library and suggesting improvements.
 
 # Licensing information
 

--- a/README.md
+++ b/README.md
@@ -48,14 +48,21 @@ make mexmat # Compile MEX interface for MATLAB.
 or
 ```console
 make mexoct # Compile MEX interface for Octave.
+
 ```
-These two commands compile and auto-tune the MEX interface in MATLAB and Octave, respectively, by using the functions `mex/cpfloat_compile.m` and `mex/cpfloat_autotune.m`.
+These two commands compile and autotune the MEX interface in MATLAB and Octave, respectively, by using the functions `mex/cpfloat_compile.m` and `mex/cpfloat_autotune.m`. To use the interface, the `bin/` folder must be in MATLAB's search path.
 
-To use the MEX interface, it suffices to add the `bin/` directory to the MATLAB search path.
+On a system where the `make` build automation tool is not available, we recommend building the MEX interface by running the script `cpfloat_compile_nomake.m` in the `mex/` folder. The script attempts to compile and auto-tune the MEX interface using the default C compiler. The following code will download the repository as a ZIP file, inflate it, and try to compile it:
 
-On a system where the `make` build automation tool is not available, we recommend building the MEX interface by running the script `cpfloat_compile_nomake.m` in the `mex/` directory. The script attempts to download the file `pcg_variants.h` and to compile and auto-tune the MEX interface using the default C compiler. A different compiler can be used by setting the value of the variable `compilerpath` appropriately.
+```matlab
+zip_url = 'https://codeload.github.com/north-numerical-computing/cpfloat/zip/refs/heads/main';
+unzip(zip_url);
+movefile('cpfloat-main', 'cpfloat')
+cd('cpfloat/mex');
+cpfloat_compile_nomake
+```
 
-If the PCG Library header file cannot be downloaded and is not already present in the `include/pcg-c/include` directory, then the interface falls back to the pseudo-random number generator in the C standard library. If the compiler does not support OpenMP, only the sequential version of the algorithm will be produced and no auto-tuning will take place.
+A different compiler can be used by setting the value of the variable `compilerpath` appropriately. We have not been able to compile the PCG Library with the C compiler recommended by MATLAB, thus by default the script uses the pseudo-random number generator in the C standard library. If the compiler does not support OpenMP, only the sequential version of the algorithm will be produced and no auto-tuning will take place.
 
 ## Auto-tuning
 

--- a/mex/cpfloat.c
+++ b/mex/cpfloat.c
@@ -39,8 +39,8 @@ void mexFunction(int nlhs,
 
     strcpy(fpopts->format, "h");
     fpopts->precision = 11;
-    fpopts->emax = 15;
     fpopts->emin = -14;
+    fpopts->emax = 15;
     fpopts->subnormal = CPFLOAT_SUBN_USE;
     fpopts->explim = CPFLOAT_EXPRANGE_TARG;
     fpopts->round = CPFLOAT_RND_NE;
@@ -78,54 +78,54 @@ void mexFunction(int nlhs,
            !strcmp(fpopts->format, "fp8-e4m3") ||
                  !strcmp(fpopts->format, "E4M3")) {
         fpopts->precision = 4;
-        fpopts->emax = 8;
         fpopts->emin = -6;
+        fpopts->emax = 8;
       } else if (!strcmp(fpopts->format, "q52") ||
                  !strcmp(fpopts->format, "fp8-e5m2") ||
                  !strcmp(fpopts->format, "E5M2")) {
         fpopts->precision = 3;
-        fpopts->emax = 15;
         fpopts->emin = -14;
+        fpopts->emax = 15;
       } else if (!strcmp(fpopts->format, "b") ||
           !strcmp(fpopts->format, "bfloat16") ||
           !strcmp(fpopts->format, "bf16")) {
         fpopts->precision = 8;
-        fpopts->emax = 127;
         fpopts->emin = -126;
+        fpopts->emax = 127;
         is_subn_rnd_default = true;
       } else if (!strcmp(fpopts->format, "h") ||
                  !strcmp(fpopts->format, "half") ||
                  !strcmp(fpopts->format, "binary16") ||
                  !strcmp(fpopts->format, "fp16")) {
         fpopts->precision = 11;
-        fpopts->emax = 15;
         fpopts->emin = -14;
+        fpopts->emax = 15;
       } else if (!strcmp(fpopts->format, "t") ||
                  !strcmp(fpopts->format, "TensorFloat-32") ||
                  !strcmp(fpopts->format, "tf32")) {
         fpopts->precision = 11;
-        fpopts->emax = 127;
         fpopts->emin = -126;
+        fpopts->emax = 127;
       } else if (!strcmp(fpopts->format, "s") ||
                  !strcmp(fpopts->format, "single") ||
                  !strcmp(fpopts->format, "binary32") ||
                  !strcmp(fpopts->format, "fp32")) {
         fpopts->precision =  24;
-        fpopts->emax = 127;
         fpopts->emin = -126;
+        fpopts->emax = 127;
       } else if (!strcmp(fpopts->format, "d") ||
                  !strcmp(fpopts->format, "double") ||
                  !strcmp(fpopts->format, "binary64") ||
                  !strcmp(fpopts->format, "fp64")) {
         fpopts->precision =   53;
-        fpopts->emax = 1023;
         fpopts->emin = -1022;
+        fpopts->emax = 1023;
       } else if (!strcmp(fpopts->format, "c") ||
                  !strcmp(fpopts->format, "custom")) {
         if ((tmp != NULL) && (mxGetClassID(tmp) == mxDOUBLE_CLASS)) {
           fpopts->precision = ((double *)mxGetData(tmp))[0];
-          fpopts->emax = ((double *)mxGetData(tmp))[1];
-          fpopts->emin = ((double *)mxGetData(tmp))[2];
+          fpopts->emin = ((double *)mxGetData(tmp))[1];
+          fpopts->emax = ((double *)mxGetData(tmp))[2];
         } else {
           mexErrMsgIdAndTxt("cpfloat:invalidparams",
                             "Invalid floating-point parameters specified.");
@@ -223,8 +223,8 @@ void mexFunction(int nlhs,
       maxebits = 1023;
       minebits = -1022;
     }
-    if (fpopts->precision > maxfbits || fpopts->emax > maxebits
-        || fpopts->emin < minebits)
+    if (fpopts->precision > maxfbits || fpopts->emin < minebits
+        ||fpopts->emax > maxebits)
       if (!strcmp(fpopts->format, "c") || !strcmp(fpopts->format, "custom"))
         mexErrMsgIdAndTxt("cpfloat:invalidparams",
                           "Invalid floating-point parameters selected.");
@@ -297,8 +297,8 @@ void mexFunction(int nlhs,
     mxArray *outparams = mxCreateDoubleMatrix(1,3,mxREAL);
     double *outparamsptr = mxGetData(outparams);
     outparamsptr[0] = fpopts->precision;
-    outparamsptr[1] = fpopts->emax;
-    outparamsptr[2] = fpopts->emin;
+    outparamsptr[1] = fpopts->emin;
+    outparamsptr[2] = fpopts->emax;
     mxSetFieldByNumber(plhs[1], 0, 1, outparams);
 
     mxArray *outsubnormal = mxCreateDoubleMatrix(1,1,mxREAL);

--- a/mex/cpfloat.c
+++ b/mex/cpfloat.c
@@ -40,7 +40,7 @@ void mexFunction(int nlhs,
     strcpy(fpopts->format, "h");
     fpopts->precision = 11;
     fpopts->emax = 15;
-    fptops->emin = -14;
+    fpopts->emin = -14;
     fpopts->subnormal = CPFLOAT_SUBN_USE;
     fpopts->explim = CPFLOAT_EXPRANGE_TARG;
     fpopts->round = CPFLOAT_RND_NE;

--- a/mex/cpfloat.c
+++ b/mex/cpfloat.c
@@ -78,6 +78,7 @@ void mexFunction(int nlhs,
                  !strcmp(fpopts->format, "E4M3")) {
         fpopts->precision = 4;
         fpopts->emax = 8;
+        fpopts->emin = -6;
       } else if (!strcmp(fpopts->format, "q52") ||
                  !strcmp(fpopts->format, "fp8-e5m2") ||
                  !strcmp(fpopts->format, "E5M2")) {

--- a/mex/cpfloat.c
+++ b/mex/cpfloat.c
@@ -77,7 +77,7 @@ void mexFunction(int nlhs,
            !strcmp(fpopts->format, "fp8-e4m3") ||
                  !strcmp(fpopts->format, "E4M3")) {
         fpopts->precision = 4;
-        fpopts->emax = 7;
+        fpopts->emax = 8;
       } else if (!strcmp(fpopts->format, "q52") ||
                  !strcmp(fpopts->format, "fp8-e5m2") ||
                  !strcmp(fpopts->format, "E5M2")) {

--- a/mex/cpfloat.c
+++ b/mex/cpfloat.c
@@ -224,7 +224,7 @@ void mexFunction(int nlhs,
       minebits = -1022;
     }
     if (fpopts->precision > maxfbits || fpopts->emax > maxebits
-        || foptions->emin < minebits)
+        || fpopts->emin < minebits)
       if (!strcmp(fpopts->format, "c") || !strcmp(fpopts->format, "custom"))
         mexErrMsgIdAndTxt("cpfloat:invalidparams",
                           "Invalid floating-point parameters selected.");

--- a/mex/cpfloat.m
+++ b/mex/cpfloat.m
@@ -19,8 +19,8 @@
 %
 %   * The string FPOPTS.format specifies the target floating-point format.
 %     Possible values are:
-%       'q43', 'fp8-e4m3', 'E4M3'          for NVIDIA E4M3;
-%       'q52', 'fp8-e5m2', 'E5M2'          for NVIDIA E5M2;
+%       'q43', 'fp8-e4m3', 'E4M3'          for OCP specification E4M3;
+%       'q52', 'fp8-e5m2', 'E5M2'          for OCP specification E5M2;
 %       'b', 'bf16', 'bfloat16'            for Intel bfloat16;
 %       'h', 'fp16', 'binary16', 'half'    for IEEE binary16 (half precision);
 %       't', 'tf32', 'TeensorFloat-32'     for NVIDIA TensorFloat-32;
@@ -31,13 +31,13 @@
 %     format must be supplied using the FPOPTS.params field. The default value
 %     for this field is 'h'.
 %
-%   * The two-element vector FPOPTS.params specifies the parameters of the
+%   * The three-element vector FPOPTS.params specifies the parameters of the
 %     target floating-point format, and is ignored unless FPOPTS.format is set
-%     to either 'c' or 'custom'. The vector has the form [PRECISION,EMAX],
-%     where PRECISION and EMAX are positive integer representing the number of
-%     binary digits in the fraction and the maximum exponent of the target
-%     format, respectively. The minimum exponent is assumed to be 1 - EMAX. The
-%     default value of this field is the vector [11,15].
+%     to either 'c' or 'custom'. The vector has the form [PRECISION,EMAX,EMIN],
+%     where PRECISION, EMAX and EMIN are positive integers representing
+%     the number of binary digits in the fraction and the maximum exponent of
+%     the target format, respectively. The default value of this field is
+%     the vector [11,15,-14].
 %
 %   * The scalar FPOPTS.subnormal specifies the support for subnormal numbers.
 %     The target floating-point format will not support subnormal numbers if
@@ -80,8 +80,9 @@
 %     probability, that is, a real number in the interval [0,1]. The default
 %     value for this field is 0.5.
 %
-%   The interface of CPFLOAT is fully compatible with that of the MATLAB
-%   function CHOP available at https://github.com/higham/chop.
+%   The interface of CPFLOAT is partly compatible with that of the MATLAB
+%   function CHOP available at https://github.com/higham/chop. The main
+%   difference is that CPFLOAT requires EMIN specified in FPOPTS.params.
 
 % SPDX-FileCopyrightText: 2020 Massimiliano Fasi and Mantas Mikaitis
 % SPDX-License-Identifier: LGPL-2.1-or-later

--- a/mex/cpfloat.m
+++ b/mex/cpfloat.m
@@ -33,11 +33,11 @@
 %
 %   * The three-element vector FPOPTS.params specifies the parameters of the
 %     target floating-point format, and is ignored unless FPOPTS.format is set
-%     to either 'c' or 'custom'. The vector has the form [PRECISION,EMAX,EMIN],
-%     where PRECISION, EMAX and EMIN are positive integers representing
+%     to either 'c' or 'custom'. The vector has the form [PRECISION,EMIN,EMAX],
+%     where PRECISION, EMIN and EMAX are positive integers representing
 %     the number of binary digits in the fraction and the maximum exponent of
 %     the target format, respectively. The default value of this field is
-%     the vector [11,15,-14].
+%     the vector [11,-14,15].
 %
 %   * The scalar FPOPTS.subnormal specifies the support for subnormal numbers.
 %     The target floating-point format will not support subnormal numbers if
@@ -80,9 +80,10 @@
 %     probability, that is, a real number in the interval [0,1]. The default
 %     value for this field is 0.5.
 %
-%   The interface of CPFLOAT is partly compatible with that of the MATLAB
-%   function CHOP available at https://github.com/higham/chop. The main
-%   difference is that CPFLOAT requires EMIN specified in FPOPTS.params.
+%   The interface of CPFLOAT is mostly compatible with that of the MATLAB
+%   function CHOP available at https://github.com/higham/chop. See
+%   https://github.com/north-numerical-computing/cpfloat/blob/main/README.md
+%   for an up-to-date list of differences.
 
 % SPDX-FileCopyrightText: 2020 Massimiliano Fasi and Mantas Mikaitis
 % SPDX-License-Identifier: LGPL-2.1-or-later

--- a/mex/cpfloat_compile.m
+++ b/mex/cpfloat_compile.m
@@ -68,7 +68,8 @@ function retval = cpfloat_compile(varargin)
       coptions = sprintf('%s -I%s', coptions, cpfloatdir)
     end
     setenv("CFLAGS", sprintf("-fopenmp %s", coptions));
-    setenv("LDFLAGS", sprintf("-fopenmp %s", clibs));
+    libpath = deblank(evalc('mkoctfile --print OCTLIBDIR'));
+    setenv("LDFLAGS", sprintf("-fopenmp %s -L%s", clibs, libpath));
     if isempty(pcglib)
       [output, status] = mkoctfile('cpfloat.c', '--mex', '--verbose');
     else
@@ -78,7 +79,7 @@ function retval = cpfloat_compile(varargin)
       warning('Compilation error, trying to compile without OpenMP.');
       retval = false;
       setenv("CFLAGS", coptions);
-      setenv("LDFLAGS", clibs)
+      setenv("LDFLAGS", sprintf("%s -L%s", clibs, libpath));
       if isempty(pcglib)
         [output, status] = mkoctfile('cpfloat.c', '--mex', '--verbose');
       else

--- a/src/cpfloat_autotune.c
+++ b/src/cpfloat_autotune.c
@@ -100,6 +100,7 @@ int main() {
   strcpy(fpopts->format,"s");
   fpopts->precision = 24;
   fpopts->emax = 127;
+  fpopts->emin = -126;
   fpopts->subnormal = 0;
   fpopts->round = 1;
   fpopts->flip = 0;

--- a/src/cpfloat_binary32.h
+++ b/src/cpfloat_binary32.h
@@ -13,211 +13,211 @@
 #include "cpfloat_docmacros.h"
 
 /* Validation of floating-point parameters. */
-doc_cpfloat_validate_optstruct(double, 12, 24, 127)
+doc_cpfloat_validate_optstruct(double, 12, 24, 127, -126)
 static inline int cpfloat_validate_optstructf(const optstruct *fpopts);
 
 /* Rounding functions. */
-doc_cpfloat(float, 24, 127)
+doc_cpfloat(float, 24, 127, -126)
 static inline int cpfloatf(float *X, const float *A, const size_t numelem,
                            optstruct *fpopts);
-doc_cpfloat(float, 24, 127)
+doc_cpfloat(float, 24, 127, -126)
 static inline int cpf_fproundf(float *X, const float *A,
                                const size_t numelem, optstruct *fpopts);
 
 /* Elementary arithmetic operations. */
-doc_cpf_bivariate(sum, \f$ X_i = A_i + B_i \f$, 24, 127)
+doc_cpf_bivariate(sum, \f$ X_i = A_i + B_i \f$, 24, 127, -126)
 static inline int cpf_addf(float *X, const float *A, const float *B,
                            const size_t numelem, optstruct *fpopts);
-doc_cpf_bivariate(difference, \f$ X_i = A_i - B_i \f$, 24, 127)
+doc_cpf_bivariate(difference, \f$ X_i = A_i - B_i \f$, 24, 127, -126)
 static inline int cpf_subf(float *X, const float *A, const float *B,
                            const size_t numelem, optstruct *fpopts);
-doc_cpf_bivariate(product, \f$ X_i = A_i \times B_i \f$, 24, 127)
+doc_cpf_bivariate(product, \f$ X_i = A_i \times B_i \f$, 24, 127, -126)
 static inline int cpf_mulf(float *X, const float *A, const float *B,
                            const size_t numelem, optstruct *fpopts);
-doc_cpf_bivariate(ratio, \f$ X_i = A_i / B_i \f$, 24, 127)
+doc_cpf_bivariate(ratio, \f$ X_i = A_i / B_i \f$, 24, 127, -126)
 static inline int cpf_divf(float *X, const float *A, const float *B,
                            const size_t numelem, optstruct *fpopts);
 
 /* Trigonometric functions. */
-doc_cpf_univariate(trigonometric cosine, \f$ X_i = \cos(A_i) \f$, 24, 127)
+doc_cpf_univariate(trigonometric cosine, \f$ X_i = \cos(A_i) \f$, 24, 127, -126)
 static inline int cpf_cosf(float *X, const float *A,
                            const size_t numelem, optstruct *fpopts);
-doc_cpf_univariate(trigonometric sine, \f$ X_i = \sin(A_i) \f$, 24, 127)
+doc_cpf_univariate(trigonometric sine, \f$ X_i = \sin(A_i) \f$, 24, 127, -126)
 static inline int cpf_sinf(float *X, const float *A,
                            const size_t numelem, optstruct *fpopts);
-doc_cpf_univariate(trigonometric tangent, \f$ X_i = \tan(A_i) \f$, 24, 127)
+doc_cpf_univariate(trigonometric tangent, \f$ X_i = \tan(A_i) \f$, 24, 127, -126)
 static inline int cpf_tanf(float *X, const float *A,
                            const size_t numelem, optstruct *fpopts);
 
 doc_cpf_univariate(inverse trigonometric cosine,
-                   \f$ X_i = \mathrm{acos}(A_i) \f$, 24, 127)
+                   \f$ X_i = \mathrm{acos}(A_i) \f$, 24, 127, -126)
 static inline int cpf_acosf(float *X, const float *A,
                             const size_t numelem, optstruct *fpopts);
 doc_cpf_univariate(inverse trigonometric sine,
-                   \f$ X_i = \mathrm{asin}(A_i) \f$, 24, 127)
+                   \f$ X_i = \mathrm{asin}(A_i) \f$, 24, 127, -126)
 static inline int cpf_asinf(float *X, const float *A,
                             const size_t numelem, optstruct *fpopts);
 doc_cpf_univariate(inverse trigonometric tangent,
-                   \f$ X_i = \mathrm{atan}(A_i) \f$, 24, 127)
+                   \f$ X_i = \mathrm{atan}(A_i) \f$, 24, 127, -126)
 static inline int cpf_atanf(float *X, const float *A,
                             const size_t numelem, optstruct *fpopts);
 doc_cpf_bivariate(2-argument arctangent,
-                  \f$ X_i = \mathrm{atan} (B_i / A_i) \f$, 24, 127)
+                  \f$ X_i = \mathrm{atan} (B_i / A_i) \f$, 24, 127, -126)
 static inline int cpf_atan2f(float *X, const float *A, const float *B,
                              const size_t numelem, optstruct *fpopts);
 
 /* Hyperbolic functions. */
-doc_cpf_univariate(hyperbolic cosine, \f$ X_i = \mathrm{cosh}(A_i) \f$, 24, 127)
+doc_cpf_univariate(hyperbolic cosine, \f$ X_i = \mathrm{cosh}(A_i) \f$, 24, 127, -126)
 static inline int cpf_coshf(float *X, const float *A,
                             const size_t numelem, optstruct *fpopts);
-doc_cpf_univariate(hyperbolic sine, \f$ X_i = \mathrm{sinh}(A_i) \f$, 24, 127)
+doc_cpf_univariate(hyperbolic sine, \f$ X_i = \mathrm{sinh}(A_i) \f$, 24, 127, -126)
 static inline int cpf_sinhf(float *X, const float *A,
                             const size_t numelem, optstruct *fpopts);
-doc_cpf_univariate(hyperbolic tangent , \f$ X_i = \mathrm{tanh}(A_i) \f$, 24, 127)
+doc_cpf_univariate(hyperbolic tangent , \f$ X_i = \mathrm{tanh}(A_i) \f$, 24, 127, -126)
 static inline int cpf_tanhf(float *X, const float *A,
                             const size_t numelem, optstruct *fpopts);
 
 doc_cpf_univariate(inverse hyperbolic cosine,
-                   \f$ X_i = \mathrm{arcosh}(A_i) \f$, 24, 127)
+                   \f$ X_i = \mathrm{arcosh}(A_i) \f$, 24, 127, -126)
 static inline int cpf_acoshf(float *X, const float *A,
                              const size_t numelem, optstruct *fpopts);
 doc_cpf_univariate(inverse hyperbolic sine,
-                   \f$ X_i = \mathrm{arsinh}(A_i) \f$, 24, 127)
+                   \f$ X_i = \mathrm{arsinh}(A_i) \f$, 24, 127, -126)
 static inline int cpf_asinhf(float *X, const float *A,
                              const size_t numelem, optstruct *fpopts);
 doc_cpf_univariate(inverse hyperbolic tangent,
-                   \f$ X_i = \mathrm{artanh}(A_i) \f$, 24, 127)
+                   \f$ X_i = \mathrm{artanh}(A_i) \f$, 24, 127, -126)
 static inline int cpf_atanhf(float *X, const float *A,
                              const size_t numelem, optstruct *fpopts);
 
 /* Exponentiation and logarithmic functions. */
-doc_cpf_univariate(exponential, \f$ X_i = \exp(A_i) \f$, 24, 127)
+doc_cpf_univariate(exponential, \f$ X_i = \exp(A_i) \f$, 24, 127, -126)
 static inline int cpf_expf(float *X, const float *A,
                            const size_t numelem, optstruct *fpopts);
 
-doc_cpf_frexp(24, 127)
+doc_cpf_frexp(24, 127, -126)
 static inline int cpf_frexpf(float *X, int *exp, const float *A,
                              const size_t numelem, optstruct *fpopts);
-doc_cpf_scaling(2, 24, 127)
+doc_cpf_scaling(2, 24, 127, -126)
 static inline int cpf_ldexpf(float *X, const float *A, const int *exp,
                              const size_t numelem, optstruct *fpopts);
-doc_cpf_univariate(natural logarithm, \f$ X_i = \log(A_i) \f$, 24, 127)
+doc_cpf_univariate(natural logarithm, \f$ X_i = \log(A_i) \f$, 24, 127, -126)
 static inline int cpf_logf(float *X, const float *A,
                            const size_t numelem, optstruct *fpopts);
-doc_cpf_univariate(base-10 logarithm, \f$ X_i = \log_{10}(A_i) \f$, 24, 127)
+doc_cpf_univariate(base-10 logarithm, \f$ X_i = \log_{10}(A_i) \f$, 24, 127, -126)
 static inline int cpf_log10f(float *X, const float *A,
                              const size_t numelem, optstruct *fpopts);
-doc_cpf_modf(24, 127)
+doc_cpf_modf(24, 127, -126)
 static inline int cpf_modff(float *X, float *intpart, const float *A,
                             const size_t numelem, optstruct *fpopts);
-doc_cpf_univariate(base-2 exponential, \f$ X_i = 2^{A_i} \f$, 24, 127)
+doc_cpf_univariate(base-2 exponential, \f$ X_i = 2^{A_i} \f$, 24, 127, -126)
 static inline int cpf_exp2f(float *X, const float *A,
                             const size_t numelem, optstruct *fpopts);
-doc_cpf_univariate(exp(x) - 1, \f$ X_i = \exp(A_i) - 1 \f$, 24, 127)
+doc_cpf_univariate(exp(x) - 1, \f$ X_i = \exp(A_i) - 1 \f$, 24, 127, -126)
 static inline int cpf_expm1f(float *X, const float *A,
                              const size_t numelem, optstruct *fpopts);
-doc_cpf_ilogb(24, 127)
+doc_cpf_ilogb(24, 127, -126)
 static inline int cpf_ilogbf(int *exp, const float *A,
                              const size_t numelem, optstruct *fpopts);
 
 doc_cpf_univariate(natural logarithm of number shifted by one,
-                   \f$ X_i = \log(1+A_i) \f$, 24, 127)
+                   \f$ X_i = \log(1+A_i) \f$, 24, 127, -126)
 static inline int cpf_log1pf(float *X, const float *A,
                              size_t numelem, optstruct *fpopts);
-doc_cpf_univariate(base-2 logarithm, \f$ X_i = \log_2(A_i) \f$, 24, 127)
+doc_cpf_univariate(base-2 logarithm, \f$ X_i = \log_2(A_i) \f$, 24, 127, -126)
 static inline int cpf_log2f(float *X, const float *A,
                             const size_t numelem, optstruct *fpopts);
 doc_cpf_univariate(base-FLT_RADIX logarithm of absolute value,
-                   \f$ X_i = \log(\lvert A_i \rvert) \f$, 24, 127)
+                   \f$ X_i = \log(\lvert A_i \rvert) \f$, 24, 127, -126)
 static inline int cpf_logbf(float *X, const float *A,
                             const size_t numelem, optstruct *fpopts);
-doc_cpf_scaling(FLT\_RADIX, 24, 127)
+doc_cpf_scaling(FLT\_RADIX, 24, 127, -126)
 static inline int cpf_scalbnf(float *X, const float *A, const int *exp,
                               const size_t numelem, optstruct *fpopts);
-doc_cpf_scaling(FLT\_RADIX, 24, 127)
+doc_cpf_scaling(FLT\_RADIX, 24, 127, -126)
 static inline int cpf_scalblnf(float *X, const float *A,
                                const long int *exp, const size_t numelem,
                                optstruct *fpopts);
 
 /* Power functions. */
-doc_cpf_bivariate(real powers, \f$ X_i = A_i^{B_i} \f$, 24, 127)
+doc_cpf_bivariate(real powers, \f$ X_i = A_i^{B_i} \f$, 24, 127, -126)
 static inline int cpf_powf(float *X, const float *A, const float *B,
                            const size_t numelem, optstruct *fpopts);
-doc_cpf_univariate(square root, \f$ X_i = \sqrt{A_i} \f$, 24, 127)
+doc_cpf_univariate(square root, \f$ X_i = \sqrt{A_i} \f$, 24, 127, -126)
 static inline int cpf_sqrtf(float *X, const float *A,
                             const size_t numelem, optstruct *fpopts);
-doc_cpf_univariate(cube root, \f$ X_i = \sqrt[3]{A_i} \f$, 24, 127)
+doc_cpf_univariate(cube root, \f$ X_i = \sqrt[3]{A_i} \f$, 24, 127, -126)
 static inline int cpf_cbrtf(float *X, const float *A,
                             const size_t numelem, optstruct *fpopts);
 doc_cpf_bivariate(hypotenuse of a right-angle triangle,
-                  \f$ X_i = \sqrt{A_i^2 + B_i^2} \f$, 24, 127)
+                  \f$ X_i = \sqrt{A_i^2 + B_i^2} \f$, 24, 127, -126)
 static inline int cpf_hypotf(float *X, const float *A, const float *B,
                              const size_t numelem, optstruct *fpopts);
 
 /* Error and gamma functions. */
-doc_cpf_univariate(error function, \f$ X_i = \mathrm{erf}(A_i) \f$, 24, 127)
+doc_cpf_univariate(error function, \f$ X_i = \mathrm{erf}(A_i) \f$, 24, 127, -126)
 static inline int cpf_erff(float *X, const float *A,
                            const size_t numelem, optstruct *fpopts);
 doc_cpf_univariate(complementary error function,
-                   \f$ X_i = \mathrm{erfc}(A_i) \f$, 24, 127)
+                   \f$ X_i = \mathrm{erfc}(A_i) \f$, 24, 127, -126)
 static inline int cpf_erfcf(float *X, const float *A,
                             const size_t numelem, optstruct *fpopts);
-doc_cpf_univariate(gamma function, \f$ X_i = \Gamma(A_i) \f$, 24, 127)
+doc_cpf_univariate(gamma function, \f$ X_i = \Gamma(A_i) \f$, 24, 127, -126)
 static inline int cpf_tgammaf(float *X, const float *A,
                               const size_t numelem, optstruct *fpopts);
 doc_cpf_univariate(natural logarithm of absolute value of gamma function,
-                   \f$ X_i = \log(\lvert \Gamma(A_i) \rvert) \f$, 24, 127)
+                   \f$ X_i = \log(\lvert \Gamma(A_i) \rvert) \f$, 24, 127, -126)
 static inline int cpf_lgammaf(float *X, const float *A,
                               const size_t numelem, optstruct *fpopts);
 
 /* Rounding and remainder functions. */
-doc_cpf_univariate(ceiling function, \f$ X_i = \lceil A_i \rceil \f$, 24, 127)
+doc_cpf_univariate(ceiling function, \f$ X_i = \lceil A_i \rceil \f$, 24, 127, -126)
 static inline int cpf_ceilf(float *X, const float *A,
                             const size_t numelem, optstruct *fpopts);
-doc_cpf_univariate(floor function, \f$ X_i = \lfloor A_i \rfloor \f$, 24, 127)
+doc_cpf_univariate(floor function, \f$ X_i = \lfloor A_i \rfloor \f$, 24, 127, -126)
 static inline int cpf_floorf(float *X, const float *A,
                              const size_t numelem, optstruct *fpopts);
 doc_cpf_bivariate(floating-point remainder of division,
-                  \f$ X_i = A_i \;\mathrm{mod}\; B_i \f$, 24, 127)
+                  \f$ X_i = A_i \;\mathrm{mod}\; B_i \f$, 24, 127, -126)
 static inline int cpf_fmodf(float *X, const float *A, const float *B,
                             const size_t numelem, optstruct *fpopts);
-doc_cpf_univariate(integer truncation, \f$ X_i = \mathrm{trunc}(A_i) \f$, 24, 127)
+doc_cpf_univariate(integer truncation, \f$ X_i = \mathrm{trunc}(A_i) \f$, 24, 127, -126)
 static inline int cpf_truncf(float *X, const float *A,
                              const size_t numelem, optstruct *fpopts);
 
 doc_cpf_univariate(closest integer (with round-to-nearest),
-                   \f$ X_i = \mathrm{round}(A_i) \f$, 24, 127)
+                   \f$ X_i = \mathrm{round}(A_i) \f$, 24, 127, -126)
 static inline int cpf_roundf(float *X, const float *A,
                              const size_t numelem, optstruct *fpopts);
 doc_cpf_univariate(closest integer (with round-to-nearest),
-                   \f$ X_i = \mathrm{round}(A_i) \f$, 24, 127)
+                   \f$ X_i = \mathrm{round}(A_i) \f$, 24, 127, -126)
 static inline int cpf_lroundf(long *X, const float *A,
                               const size_t numelem, optstruct *fpopts);
 doc_cpf_univariate_nobitflip(closest integer (with round-to-nearest),
-                             \f$ X_i = \mathrm{round}(A_i) \f$, 24, 127)
+                             \f$ X_i = \mathrm{round}(A_i) \f$, 24, 127, -126)
 static inline int cpf_llroundf(long long *X, const float *A,
                                const size_t numelem, optstruct *fpopts);
 
-doc_cpf_rint(PMAX, EMAX)
+doc_cpf_rint(PMAX, 127, -126)
 static inline int cpf_rintf(float *X, int *exception, const float *A,
                             const size_t numelem, optstruct *fpopts);
-doc_cpf_rint(PMAX, EMAX)
+doc_cpf_rint(24, 127, -126)
 static inline int cpf_lrintf(long *X, int *exception, const float *A,
                              const size_t numelem, optstruct *fpopts);
-doc_cpf_rint(PMAX, EMAX)
+doc_cpf_rint(24, 127, -126)
 static inline int cpf_llrintf(long long *X, int *exception, const float *A,
                              const size_t numelem, optstruct *fpopts);
-doc_cpf_nearbyint(PMAX, EMAX)
+doc_cpf_nearbyint(24, 127, -126)
 static inline int cpf_nearbyintf(float *X, const float *A,
                                  const size_t numelem, optstruct *fpopts);
 doc_cpf_bivariate(remainder of the floating point division,
                   \f$ X_i = A_i^2 - k \times B_i \f$
                   for largest \f$ k \f$ such that \f$ k \times B_i < A_i \f$,
-                  24, 127)
+                  24, 127, -126)
 static inline int cpf_remainderf(float *X, const float *A, const float *B,
                                  const size_t numelem, optstruct *fpopts);
 
-doc_cpf_remquo(PMAX, EMAX)
+doc_cpf_remquo(24, 127, -126)
 static inline int cpf_remquof(float *X, int *quot,
                               const float *A, const float *B,
                               const size_t numelem, optstruct *fpopts);
@@ -225,17 +225,17 @@ static inline int cpf_remquof(float *X, int *quot,
 /* Floating-point manipulation functions. */
 doc_cpf_bivariate(number from magnitude and sign,
                   \f$ X_i = \mathrm{sign}(A_i) \times \lvert B_i \rvert \f$,
-                  24, 127)
+                  24, 127, -126)
 static inline int cpf_copysignf(float *X, const float *A, const float *B,
                                 const size_t numelem, optstruct *fpopts);
 doc_cpf_bivariate(next floating-point number in specified direction,
                   the floating-point number closest to \f$ A_i \f$ in the
-                  direction of \f$ B_i \f$, 24, 127)
+                  direction of \f$ B_i \f$, 24, 127, -126)
 static inline int cpf_nextafterf(float *X, const float *A, const float *B,
                                  const size_t numelem, optstruct *fpopts);
 doc_cpf_bivariate(next floating-point number in specified direction,
                   the floating-point number closest to \f$ A_i \f$ in the
-                  direction of \f$ B_i \f$, 24, 127)
+                  direction of \f$ B_i \f$, 24, 127, -126)
 static inline int cpf_nexttowardf(float *X, const float *A,
                                   const long double *B,
                                   const size_t numelem,
@@ -243,41 +243,41 @@ static inline int cpf_nexttowardf(float *X, const float *A,
 
 /* Minimum, maximum, difference functions. */
 doc_cpf_bivariate(positive difference, \f$ X_i = \lvert A_i - B_i \rvert \f$,
-                  24, 127)
+                  24, 127, -126)
 static inline int cpf_fdimf(float *X, const float *A, const float *B,
                             const size_t numelem, optstruct *fpopts);
 doc_cpf_bivariate(element-wise maximum, \f$ X_i = \mathrm{max}(A_i, B_i) \f$,
-                  24, 127)
+                  24, 127, -126)
 static inline int cpf_fmaxf(float *X, const float *A, const float *B,
                             const size_t numelem, optstruct *fpopts);
 doc_cpf_bivariate(element-wise minimum, \f$ X_i = \mathrm{min}(A_i, B_i) \f$,
-                  24, 127)
+                  24, 127, -126)
 static inline int cpf_fminf(float *X, const float *A, const float *B,
                             const size_t numelem, optstruct *fpopts);
 
 /* Classification. */
-doc_cpf_fpclassify(24, 127)
+doc_cpf_fpclassify(24, 127, -126)
 static inline int cpf_fpclassifyf(int *r, const float *A,
                                   const size_t numelem, optstruct *fpopts);
-doc_cpf_isfun(finite, 24, 127)
+doc_cpf_isfun(finite, 24, 127, -126)
 static inline int cpf_isfinitef(int *r, const float *A,
                                 const size_t numelem, optstruct *fpopts);
-doc_cpf_isfun(infinite, 24, 127)
+doc_cpf_isfun(infinite, 24, 127, -126)
 static inline int cpf_isinff(int *r, const float *A,
                              const size_t numelem, optstruct *fpopts);
-doc_cpf_isfun(not a number, 24, 127)
+doc_cpf_isfun(not a number, 24, 127, -126)
 static inline int cpf_isnanf(int *r, const float *A,
                              const size_t numelem, optstruct *fpopts);
-doc_cpf_isfun(normal, 24, 127)
+doc_cpf_isfun(normal, 24, 127, -126)
 static inline int cpf_isnormalf(int *r, const float *A,
                                 const size_t numelem, optstruct *fpopts);
 
 /* Other functions. */
-doc_cpf_univariate(absolute value, \f$ X_i = \lvert A_i \rvert \f$, 24, 127)
+doc_cpf_univariate(absolute value, \f$ X_i = \lvert A_i \rvert \f$, 24, 127, -126)
 static inline int cpf_fabsf(float *X, const float *A,
                             const size_t numelem, optstruct *fpopts);
 doc_cpf_trivariate(fused multiply-add , \f$ X_i = A_i \times B_i + C_i \f$,
-                   24, 127)
+                   24, 127, -126)
 static inline int cpf_fmaf(float *X, const float *A, const float *B,
                            const float *C, const size_t numelem,
                            optstruct *fpopts);

--- a/src/cpfloat_binary32.h
+++ b/src/cpfloat_binary32.h
@@ -13,211 +13,211 @@
 #include "cpfloat_docmacros.h"
 
 /* Validation of floating-point parameters. */
-doc_cpfloat_validate_optstruct(double, 12, 24, 127, -126)
+doc_cpfloat_validate_optstruct(double, 12, 24, -126, 127)
 static inline int cpfloat_validate_optstructf(const optstruct *fpopts);
 
 /* Rounding functions. */
-doc_cpfloat(float, 24, 127, -126)
+doc_cpfloat(float, 24, -126, 127)
 static inline int cpfloatf(float *X, const float *A, const size_t numelem,
                            optstruct *fpopts);
-doc_cpfloat(float, 24, 127, -126)
+doc_cpfloat(float, 24, -126, 127)
 static inline int cpf_fproundf(float *X, const float *A,
                                const size_t numelem, optstruct *fpopts);
 
 /* Elementary arithmetic operations. */
-doc_cpf_bivariate(sum, \f$ X_i = A_i + B_i \f$, 24, 127, -126)
+doc_cpf_bivariate(sum, \f$ X_i = A_i + B_i \f$, 24, -126, 127)
 static inline int cpf_addf(float *X, const float *A, const float *B,
                            const size_t numelem, optstruct *fpopts);
-doc_cpf_bivariate(difference, \f$ X_i = A_i - B_i \f$, 24, 127, -126)
+doc_cpf_bivariate(difference, \f$ X_i = A_i - B_i \f$, 24, -126, 127)
 static inline int cpf_subf(float *X, const float *A, const float *B,
                            const size_t numelem, optstruct *fpopts);
-doc_cpf_bivariate(product, \f$ X_i = A_i \times B_i \f$, 24, 127, -126)
+doc_cpf_bivariate(product, \f$ X_i = A_i \times B_i \f$, 24, -126, 127)
 static inline int cpf_mulf(float *X, const float *A, const float *B,
                            const size_t numelem, optstruct *fpopts);
-doc_cpf_bivariate(ratio, \f$ X_i = A_i / B_i \f$, 24, 127, -126)
+doc_cpf_bivariate(ratio, \f$ X_i = A_i / B_i \f$, 24, -126, 127)
 static inline int cpf_divf(float *X, const float *A, const float *B,
                            const size_t numelem, optstruct *fpopts);
 
 /* Trigonometric functions. */
-doc_cpf_univariate(trigonometric cosine, \f$ X_i = \cos(A_i) \f$, 24, 127, -126)
+doc_cpf_univariate(trigonometric cosine, \f$ X_i = \cos(A_i) \f$, 24, -126, 127)
 static inline int cpf_cosf(float *X, const float *A,
                            const size_t numelem, optstruct *fpopts);
-doc_cpf_univariate(trigonometric sine, \f$ X_i = \sin(A_i) \f$, 24, 127, -126)
+doc_cpf_univariate(trigonometric sine, \f$ X_i = \sin(A_i) \f$, 24, -126, 127)
 static inline int cpf_sinf(float *X, const float *A,
                            const size_t numelem, optstruct *fpopts);
-doc_cpf_univariate(trigonometric tangent, \f$ X_i = \tan(A_i) \f$, 24, 127, -126)
+doc_cpf_univariate(trigonometric tangent, \f$ X_i = \tan(A_i) \f$, 24, -126, 127)
 static inline int cpf_tanf(float *X, const float *A,
                            const size_t numelem, optstruct *fpopts);
 
 doc_cpf_univariate(inverse trigonometric cosine,
-                   \f$ X_i = \mathrm{acos}(A_i) \f$, 24, 127, -126)
+                   \f$ X_i = \mathrm{acos}(A_i) \f$, 24, -126, 127)
 static inline int cpf_acosf(float *X, const float *A,
                             const size_t numelem, optstruct *fpopts);
 doc_cpf_univariate(inverse trigonometric sine,
-                   \f$ X_i = \mathrm{asin}(A_i) \f$, 24, 127, -126)
+                   \f$ X_i = \mathrm{asin}(A_i) \f$, 24, -126, 127)
 static inline int cpf_asinf(float *X, const float *A,
                             const size_t numelem, optstruct *fpopts);
 doc_cpf_univariate(inverse trigonometric tangent,
-                   \f$ X_i = \mathrm{atan}(A_i) \f$, 24, 127, -126)
+                   \f$ X_i = \mathrm{atan}(A_i) \f$, 24, -126, 127)
 static inline int cpf_atanf(float *X, const float *A,
                             const size_t numelem, optstruct *fpopts);
 doc_cpf_bivariate(2-argument arctangent,
-                  \f$ X_i = \mathrm{atan} (B_i / A_i) \f$, 24, 127, -126)
+                  \f$ X_i = \mathrm{atan} (B_i / A_i) \f$, 24, -126, 127)
 static inline int cpf_atan2f(float *X, const float *A, const float *B,
                              const size_t numelem, optstruct *fpopts);
 
 /* Hyperbolic functions. */
-doc_cpf_univariate(hyperbolic cosine, \f$ X_i = \mathrm{cosh}(A_i) \f$, 24, 127, -126)
+doc_cpf_univariate(hyperbolic cosine, \f$ X_i = \mathrm{cosh}(A_i) \f$, 24, -126, 127)
 static inline int cpf_coshf(float *X, const float *A,
                             const size_t numelem, optstruct *fpopts);
-doc_cpf_univariate(hyperbolic sine, \f$ X_i = \mathrm{sinh}(A_i) \f$, 24, 127, -126)
+doc_cpf_univariate(hyperbolic sine, \f$ X_i = \mathrm{sinh}(A_i) \f$, 24, -126, 127)
 static inline int cpf_sinhf(float *X, const float *A,
                             const size_t numelem, optstruct *fpopts);
-doc_cpf_univariate(hyperbolic tangent , \f$ X_i = \mathrm{tanh}(A_i) \f$, 24, 127, -126)
+doc_cpf_univariate(hyperbolic tangent , \f$ X_i = \mathrm{tanh}(A_i) \f$, 24, -126, 127)
 static inline int cpf_tanhf(float *X, const float *A,
                             const size_t numelem, optstruct *fpopts);
 
 doc_cpf_univariate(inverse hyperbolic cosine,
-                   \f$ X_i = \mathrm{arcosh}(A_i) \f$, 24, 127, -126)
+                   \f$ X_i = \mathrm{arcosh}(A_i) \f$, 24, -126, 127)
 static inline int cpf_acoshf(float *X, const float *A,
                              const size_t numelem, optstruct *fpopts);
 doc_cpf_univariate(inverse hyperbolic sine,
-                   \f$ X_i = \mathrm{arsinh}(A_i) \f$, 24, 127, -126)
+                   \f$ X_i = \mathrm{arsinh}(A_i) \f$, 24, -126, 127)
 static inline int cpf_asinhf(float *X, const float *A,
                              const size_t numelem, optstruct *fpopts);
 doc_cpf_univariate(inverse hyperbolic tangent,
-                   \f$ X_i = \mathrm{artanh}(A_i) \f$, 24, 127, -126)
+                   \f$ X_i = \mathrm{artanh}(A_i) \f$, 24, -126, 127)
 static inline int cpf_atanhf(float *X, const float *A,
                              const size_t numelem, optstruct *fpopts);
 
 /* Exponentiation and logarithmic functions. */
-doc_cpf_univariate(exponential, \f$ X_i = \exp(A_i) \f$, 24, 127, -126)
+doc_cpf_univariate(exponential, \f$ X_i = \exp(A_i) \f$, 24, -126, 127)
 static inline int cpf_expf(float *X, const float *A,
                            const size_t numelem, optstruct *fpopts);
 
-doc_cpf_frexp(24, 127, -126)
+doc_cpf_frexp(24, -126, 127)
 static inline int cpf_frexpf(float *X, int *exp, const float *A,
                              const size_t numelem, optstruct *fpopts);
-doc_cpf_scaling(2, 24, 127, -126)
+doc_cpf_scaling(2, 24, -126, 127)
 static inline int cpf_ldexpf(float *X, const float *A, const int *exp,
                              const size_t numelem, optstruct *fpopts);
-doc_cpf_univariate(natural logarithm, \f$ X_i = \log(A_i) \f$, 24, 127, -126)
+doc_cpf_univariate(natural logarithm, \f$ X_i = \log(A_i) \f$, 24, -126, 127)
 static inline int cpf_logf(float *X, const float *A,
                            const size_t numelem, optstruct *fpopts);
-doc_cpf_univariate(base-10 logarithm, \f$ X_i = \log_{10}(A_i) \f$, 24, 127, -126)
+doc_cpf_univariate(base-10 logarithm, \f$ X_i = \log_{10}(A_i) \f$, 24, -126, 127)
 static inline int cpf_log10f(float *X, const float *A,
                              const size_t numelem, optstruct *fpopts);
-doc_cpf_modf(24, 127, -126)
+doc_cpf_modf(24, -126, 127)
 static inline int cpf_modff(float *X, float *intpart, const float *A,
                             const size_t numelem, optstruct *fpopts);
-doc_cpf_univariate(base-2 exponential, \f$ X_i = 2^{A_i} \f$, 24, 127, -126)
+doc_cpf_univariate(base-2 exponential, \f$ X_i = 2^{A_i} \f$, 24, -126, 127)
 static inline int cpf_exp2f(float *X, const float *A,
                             const size_t numelem, optstruct *fpopts);
-doc_cpf_univariate(exp(x) - 1, \f$ X_i = \exp(A_i) - 1 \f$, 24, 127, -126)
+doc_cpf_univariate(exp(x) - 1, \f$ X_i = \exp(A_i) - 1 \f$, 24, -126, 127)
 static inline int cpf_expm1f(float *X, const float *A,
                              const size_t numelem, optstruct *fpopts);
-doc_cpf_ilogb(24, 127, -126)
+doc_cpf_ilogb(24, -126, 127)
 static inline int cpf_ilogbf(int *exp, const float *A,
                              const size_t numelem, optstruct *fpopts);
 
 doc_cpf_univariate(natural logarithm of number shifted by one,
-                   \f$ X_i = \log(1+A_i) \f$, 24, 127, -126)
+                   \f$ X_i = \log(1+A_i) \f$, 24, -126, 127)
 static inline int cpf_log1pf(float *X, const float *A,
                              size_t numelem, optstruct *fpopts);
-doc_cpf_univariate(base-2 logarithm, \f$ X_i = \log_2(A_i) \f$, 24, 127, -126)
+doc_cpf_univariate(base-2 logarithm, \f$ X_i = \log_2(A_i) \f$, 24, -126, 127)
 static inline int cpf_log2f(float *X, const float *A,
                             const size_t numelem, optstruct *fpopts);
 doc_cpf_univariate(base-FLT_RADIX logarithm of absolute value,
-                   \f$ X_i = \log(\lvert A_i \rvert) \f$, 24, 127, -126)
+                   \f$ X_i = \log(\lvert A_i \rvert) \f$, 24, -126, 127)
 static inline int cpf_logbf(float *X, const float *A,
                             const size_t numelem, optstruct *fpopts);
-doc_cpf_scaling(FLT\_RADIX, 24, 127, -126)
+doc_cpf_scaling(FLT\_RADIX, 24, -126, 127)
 static inline int cpf_scalbnf(float *X, const float *A, const int *exp,
                               const size_t numelem, optstruct *fpopts);
-doc_cpf_scaling(FLT\_RADIX, 24, 127, -126)
+doc_cpf_scaling(FLT\_RADIX, 24, -126, 127)
 static inline int cpf_scalblnf(float *X, const float *A,
                                const long int *exp, const size_t numelem,
                                optstruct *fpopts);
 
 /* Power functions. */
-doc_cpf_bivariate(real powers, \f$ X_i = A_i^{B_i} \f$, 24, 127, -126)
+doc_cpf_bivariate(real powers, \f$ X_i = A_i^{B_i} \f$, 24, -126, 127)
 static inline int cpf_powf(float *X, const float *A, const float *B,
                            const size_t numelem, optstruct *fpopts);
-doc_cpf_univariate(square root, \f$ X_i = \sqrt{A_i} \f$, 24, 127, -126)
+doc_cpf_univariate(square root, \f$ X_i = \sqrt{A_i} \f$, 24, -126, 127)
 static inline int cpf_sqrtf(float *X, const float *A,
                             const size_t numelem, optstruct *fpopts);
-doc_cpf_univariate(cube root, \f$ X_i = \sqrt[3]{A_i} \f$, 24, 127, -126)
+doc_cpf_univariate(cube root, \f$ X_i = \sqrt[3]{A_i} \f$, 24, -126, 127)
 static inline int cpf_cbrtf(float *X, const float *A,
                             const size_t numelem, optstruct *fpopts);
 doc_cpf_bivariate(hypotenuse of a right-angle triangle,
-                  \f$ X_i = \sqrt{A_i^2 + B_i^2} \f$, 24, 127, -126)
+                  \f$ X_i = \sqrt{A_i^2 + B_i^2} \f$, 24, -126, 127)
 static inline int cpf_hypotf(float *X, const float *A, const float *B,
                              const size_t numelem, optstruct *fpopts);
 
 /* Error and gamma functions. */
-doc_cpf_univariate(error function, \f$ X_i = \mathrm{erf}(A_i) \f$, 24, 127, -126)
+doc_cpf_univariate(error function, \f$ X_i = \mathrm{erf}(A_i) \f$, 24, -126, 127)
 static inline int cpf_erff(float *X, const float *A,
                            const size_t numelem, optstruct *fpopts);
 doc_cpf_univariate(complementary error function,
-                   \f$ X_i = \mathrm{erfc}(A_i) \f$, 24, 127, -126)
+                   \f$ X_i = \mathrm{erfc}(A_i) \f$, 24, -126, 127)
 static inline int cpf_erfcf(float *X, const float *A,
                             const size_t numelem, optstruct *fpopts);
-doc_cpf_univariate(gamma function, \f$ X_i = \Gamma(A_i) \f$, 24, 127, -126)
+doc_cpf_univariate(gamma function, \f$ X_i = \Gamma(A_i) \f$, 24, -126, 127)
 static inline int cpf_tgammaf(float *X, const float *A,
                               const size_t numelem, optstruct *fpopts);
 doc_cpf_univariate(natural logarithm of absolute value of gamma function,
-                   \f$ X_i = \log(\lvert \Gamma(A_i) \rvert) \f$, 24, 127, -126)
+                   \f$ X_i = \log(\lvert \Gamma(A_i) \rvert) \f$, 24, -126, 127)
 static inline int cpf_lgammaf(float *X, const float *A,
                               const size_t numelem, optstruct *fpopts);
 
 /* Rounding and remainder functions. */
-doc_cpf_univariate(ceiling function, \f$ X_i = \lceil A_i \rceil \f$, 24, 127, -126)
+doc_cpf_univariate(ceiling function, \f$ X_i = \lceil A_i \rceil \f$, 24, -126, 127)
 static inline int cpf_ceilf(float *X, const float *A,
                             const size_t numelem, optstruct *fpopts);
-doc_cpf_univariate(floor function, \f$ X_i = \lfloor A_i \rfloor \f$, 24, 127, -126)
+doc_cpf_univariate(floor function, \f$ X_i = \lfloor A_i \rfloor \f$, 24, -126, 127)
 static inline int cpf_floorf(float *X, const float *A,
                              const size_t numelem, optstruct *fpopts);
 doc_cpf_bivariate(floating-point remainder of division,
-                  \f$ X_i = A_i \;\mathrm{mod}\; B_i \f$, 24, 127, -126)
+                  \f$ X_i = A_i \;\mathrm{mod}\; B_i \f$, 24, -126, 127)
 static inline int cpf_fmodf(float *X, const float *A, const float *B,
                             const size_t numelem, optstruct *fpopts);
-doc_cpf_univariate(integer truncation, \f$ X_i = \mathrm{trunc}(A_i) \f$, 24, 127, -126)
+doc_cpf_univariate(integer truncation, \f$ X_i = \mathrm{trunc}(A_i) \f$, 24, -126, 127)
 static inline int cpf_truncf(float *X, const float *A,
                              const size_t numelem, optstruct *fpopts);
 
 doc_cpf_univariate(closest integer (with round-to-nearest),
-                   \f$ X_i = \mathrm{round}(A_i) \f$, 24, 127, -126)
+                   \f$ X_i = \mathrm{round}(A_i) \f$, 24, -126, 127)
 static inline int cpf_roundf(float *X, const float *A,
                              const size_t numelem, optstruct *fpopts);
 doc_cpf_univariate(closest integer (with round-to-nearest),
-                   \f$ X_i = \mathrm{round}(A_i) \f$, 24, 127, -126)
+                   \f$ X_i = \mathrm{round}(A_i) \f$, 24, -126, 127)
 static inline int cpf_lroundf(long *X, const float *A,
                               const size_t numelem, optstruct *fpopts);
 doc_cpf_univariate_nobitflip(closest integer (with round-to-nearest),
-                             \f$ X_i = \mathrm{round}(A_i) \f$, 24, 127, -126)
+                             \f$ X_i = \mathrm{round}(A_i) \f$, 24, -126, 127)
 static inline int cpf_llroundf(long long *X, const float *A,
                                const size_t numelem, optstruct *fpopts);
 
-doc_cpf_rint(PMAX, 127, -126)
+doc_cpf_rint(PMAX, -126, 127)
 static inline int cpf_rintf(float *X, int *exception, const float *A,
                             const size_t numelem, optstruct *fpopts);
-doc_cpf_rint(24, 127, -126)
+doc_cpf_rint(24, -126, 127)
 static inline int cpf_lrintf(long *X, int *exception, const float *A,
                              const size_t numelem, optstruct *fpopts);
-doc_cpf_rint(24, 127, -126)
+doc_cpf_rint(24, -126, 127)
 static inline int cpf_llrintf(long long *X, int *exception, const float *A,
                              const size_t numelem, optstruct *fpopts);
-doc_cpf_nearbyint(24, 127, -126)
+doc_cpf_nearbyint(24, -126, 127)
 static inline int cpf_nearbyintf(float *X, const float *A,
                                  const size_t numelem, optstruct *fpopts);
 doc_cpf_bivariate(remainder of the floating point division,
                   \f$ X_i = A_i^2 - k \times B_i \f$
                   for largest \f$ k \f$ such that \f$ k \times B_i < A_i \f$,
-                  24, 127, -126)
+                  24, -126, 127)
 static inline int cpf_remainderf(float *X, const float *A, const float *B,
                                  const size_t numelem, optstruct *fpopts);
 
-doc_cpf_remquo(24, 127, -126)
+doc_cpf_remquo(24, -126, 127)
 static inline int cpf_remquof(float *X, int *quot,
                               const float *A, const float *B,
                               const size_t numelem, optstruct *fpopts);
@@ -225,17 +225,17 @@ static inline int cpf_remquof(float *X, int *quot,
 /* Floating-point manipulation functions. */
 doc_cpf_bivariate(number from magnitude and sign,
                   \f$ X_i = \mathrm{sign}(A_i) \times \lvert B_i \rvert \f$,
-                  24, 127, -126)
+                  24, -126, 127)
 static inline int cpf_copysignf(float *X, const float *A, const float *B,
                                 const size_t numelem, optstruct *fpopts);
 doc_cpf_bivariate(next floating-point number in specified direction,
                   the floating-point number closest to \f$ A_i \f$ in the
-                  direction of \f$ B_i \f$, 24, 127, -126)
+                  direction of \f$ B_i \f$, 24, -126, 127)
 static inline int cpf_nextafterf(float *X, const float *A, const float *B,
                                  const size_t numelem, optstruct *fpopts);
 doc_cpf_bivariate(next floating-point number in specified direction,
                   the floating-point number closest to \f$ A_i \f$ in the
-                  direction of \f$ B_i \f$, 24, 127, -126)
+                  direction of \f$ B_i \f$, 24, -126, 127)
 static inline int cpf_nexttowardf(float *X, const float *A,
                                   const long double *B,
                                   const size_t numelem,
@@ -243,41 +243,41 @@ static inline int cpf_nexttowardf(float *X, const float *A,
 
 /* Minimum, maximum, difference functions. */
 doc_cpf_bivariate(positive difference, \f$ X_i = \lvert A_i - B_i \rvert \f$,
-                  24, 127, -126)
+                  24, -126, 127)
 static inline int cpf_fdimf(float *X, const float *A, const float *B,
                             const size_t numelem, optstruct *fpopts);
 doc_cpf_bivariate(element-wise maximum, \f$ X_i = \mathrm{max}(A_i, B_i) \f$,
-                  24, 127, -126)
+                  24, -126, 127)
 static inline int cpf_fmaxf(float *X, const float *A, const float *B,
                             const size_t numelem, optstruct *fpopts);
 doc_cpf_bivariate(element-wise minimum, \f$ X_i = \mathrm{min}(A_i, B_i) \f$,
-                  24, 127, -126)
+                  24, -126, 127)
 static inline int cpf_fminf(float *X, const float *A, const float *B,
                             const size_t numelem, optstruct *fpopts);
 
 /* Classification. */
-doc_cpf_fpclassify(24, 127, -126)
+doc_cpf_fpclassify(24, -126, 127)
 static inline int cpf_fpclassifyf(int *r, const float *A,
                                   const size_t numelem, optstruct *fpopts);
-doc_cpf_isfun(finite, 24, 127, -126)
+doc_cpf_isfun(finite, 24, -126, 127)
 static inline int cpf_isfinitef(int *r, const float *A,
                                 const size_t numelem, optstruct *fpopts);
-doc_cpf_isfun(infinite, 24, 127, -126)
+doc_cpf_isfun(infinite, 24, -126, 127)
 static inline int cpf_isinff(int *r, const float *A,
                              const size_t numelem, optstruct *fpopts);
-doc_cpf_isfun(not a number, 24, 127, -126)
+doc_cpf_isfun(not a number, 24, -126, 127)
 static inline int cpf_isnanf(int *r, const float *A,
                              const size_t numelem, optstruct *fpopts);
-doc_cpf_isfun(normal, 24, 127, -126)
+doc_cpf_isfun(normal, 24, -126, 127)
 static inline int cpf_isnormalf(int *r, const float *A,
                                 const size_t numelem, optstruct *fpopts);
 
 /* Other functions. */
-doc_cpf_univariate(absolute value, \f$ X_i = \lvert A_i \rvert \f$, 24, 127, -126)
+doc_cpf_univariate(absolute value, \f$ X_i = \lvert A_i \rvert \f$, 24, -126, 127)
 static inline int cpf_fabsf(float *X, const float *A,
                             const size_t numelem, optstruct *fpopts);
 doc_cpf_trivariate(fused multiply-add , \f$ X_i = A_i \times B_i + C_i \f$,
-                   24, 127, -126)
+                   24, -126, 127)
 static inline int cpf_fmaf(float *X, const float *A, const float *B,
                            const float *C, const size_t numelem,
                            optstruct *fpopts);

--- a/src/cpfloat_binary64.h
+++ b/src/cpfloat_binary64.h
@@ -13,272 +13,272 @@
 #include "cpfloat_docmacros.h"
 
 /* Validation of floating-point parameters. */
-doc_cpfloat_validate_optstruct(double, 26, 53, 1023)
+doc_cpfloat_validate_optstruct(double, 26, 53, 1023, -1022)
 static inline int cpfloat_validate_optstruct(const optstruct *fpopts);
 
 /* Rounding functions. */
-doc_cpfloat(double, 53, 1023)
+doc_cpfloat(double, 53, 1023, -1022)
 static inline int cpfloat(double *X, const double *A, const size_t numelem,
                           optstruct *fpopts);
-doc_cpfloat(double, 53, 1023)
+doc_cpfloat(double, 53, 1023, -1022)
 static inline int cpf_fpround(double *X, const double *A,
                               const size_t numelem, optstruct *fpopts);
 
 /* Elementary arithmetic operations. */
-doc_cpf_bivariate(sum, \f$ X_i = A_i + B_i \f$, 53, 1023)
+doc_cpf_bivariate(sum, \f$ X_i = A_i + B_i \f$, 53, 1023, -1022)
 static inline int cpf_add(double *X, const double *A, const double *B,
                           const size_t numelem, optstruct *fpopts);
-doc_cpf_bivariate(difference, \f$ X_i = A_i - B_i \f$, 53, 1023)
+doc_cpf_bivariate(difference, \f$ X_i = A_i - B_i \f$, 53, 1023, -1022)
 static inline int cpf_sub(double *X, const double *A, const double *B,
                           const size_t numelem, optstruct *fpopts);
-doc_cpf_bivariate(product, \f$ X_i = A_i \times B_i \f$, 53, 1023)
+doc_cpf_bivariate(product, \f$ X_i = A_i \times B_i \f$, 53, 1023, -1022)
 static inline int cpf_mul(double *X, const double *A, const double *B,
                           const size_t numelem, optstruct *fpopts);
-doc_cpf_bivariate(ratio, \f$ X_i = A_i / B_i \f$, 53, 1023)
+doc_cpf_bivariate(ratio, \f$ X_i = A_i / B_i \f$, 53, 1023, -1022)
 static inline int cpf_div(double *X, const double *A, const double *B,
                           const size_t numelem, optstruct *fpopts);
 
 /* Trigonometric functions. */
-doc_cpf_univariate(trigonometric cosine, \f$ X_i = \cos(A_i) \f$, 53, 1023)
+doc_cpf_univariate(trigonometric cosine, \f$ X_i = \cos(A_i) \f$, 53, 1023, -1022)
 static inline int cpf_cos(double *X, const double *A,
                           const size_t numelem, optstruct *fpopts);
-doc_cpf_univariate(trigonometric sine, \f$ X_i = \sin(A_i) \f$, 53, 1023)
+doc_cpf_univariate(trigonometric sine, \f$ X_i = \sin(A_i) \f$, 53, 1023, -1022)
 static inline int cpf_sin(double *X, const double *A,
                           const size_t numelem, optstruct *fpopts);
-doc_cpf_univariate(trigonometric tangent, \f$ X_i = \tan(A_i) \f$, 53, 1023)
+doc_cpf_univariate(trigonometric tangent, \f$ X_i = \tan(A_i) \f$, 53, 1023, -1022)
 static inline int cpf_tan(double *X, const double *A,
                           const size_t numelem, optstruct *fpopts);
 
 doc_cpf_univariate(inverse trigonometric cosine,
-                   \f$ X_i = \mathrm{acos(A_i)} \f$, 53, 1023)
+                   \f$ X_i = \mathrm{acos(A_i)} \f$, 53, 1023, -1022)
 static inline int cpf_acos(double *X, const double *A,
                            const size_t numelem, optstruct *fpopts);
 doc_cpf_univariate(inverse trigonometric sine,
-                   \f$ X_i = \mathrm{asin}(A_i) \f$, 53, 1023)
+                   \f$ X_i = \mathrm{asin}(A_i) \f$, 53, 1023, -1022)
 static inline int cpf_asin(double *X, const double *A,
                            const size_t numelem, optstruct *fpopts);
 doc_cpf_univariate(inverse trigonometric tangent,
-                   \f$ X_i = \mathrm{atan}(A_i) \f$, 53, 1023)
+                   \f$ X_i = \mathrm{atan}(A_i) \f$, 53, 1023, -1022)
 static inline int cpf_atan(double *X, const double *A,
                            const size_t numelem, optstruct *fpopts);
 doc_cpf_bivariate(2-argument arctangent,
-                  \f$ X_i = \mathrm{atan}(B_i / A_i) \f$, 53, 1023)
+                  \f$ X_i = \mathrm{atan}(B_i / A_i) \f$, 53, 1023, -1022)
 static inline int cpf_atan2(double *X, const double *A, const double *B,
                             const size_t numelem, optstruct *fpopts);
 
 /* Hyperbolic functions. */
 doc_cpf_univariate(hyperbolic cosine, \f$ X_i = \mathrm{cosh}(A_i) \f$,
-                   53, 1023)
+                   53, 1023, -1022)
 static inline int cpf_cosh(double *X, const double *A,
                            const size_t numelem, optstruct *fpopts);
-doc_cpf_univariate(hyperbolic sine, \f$ X_i = \mathrm{sinh}(A_i) \f$, 53, 1023)
+doc_cpf_univariate(hyperbolic sine, \f$ X_i = \mathrm{sinh}(A_i) \f$, 53, 1023, -1022)
 static inline int cpf_sinh(double *X, const double *A,
                            const size_t numelem, optstruct *fpopts);
 doc_cpf_univariate(hyperbolic tangent , \f$ X_i = \mathrm{tanh}(A_i) \f$,
-                   53, 1023)
+                   53, 1023, -1022)
 static inline int cpf_tanh(double *X, const double *A,
                            const size_t numelem, optstruct *fpopts);
 
 doc_cpf_univariate(inverse hyperbolic cosine,
-                   \f$ X_i = \mathrm{arcosh}(A_i) \f$, 53, 1023)
+                   \f$ X_i = \mathrm{arcosh}(A_i) \f$, 53, 1023, -1022)
 static inline int cpf_acosh(double *X, const double *A,
                             const size_t numelem, optstruct *fpopts);
 doc_cpf_univariate(inverse hyperbolic sine,
-                   \f$ X_i = \mathrm{arsinh}(A_i) \f$, 53, 1023)
+                   \f$ X_i = \mathrm{arsinh}(A_i) \f$, 53, 1023, -1022)
 static inline int cpf_asinh(double *X, const double *A,
                             const size_t numelem, optstruct *fpopts);
 doc_cpf_univariate(inverse hyperbolic tangent,
-                   \f$ X_i = \mathrm{artanh}(A_i) \f$, 53, 1023)
+                   \f$ X_i = \mathrm{artanh}(A_i) \f$, 53, 1023, -1022)
 static inline int cpf_atanh(double *X, const double *A,
                             const size_t numelem, optstruct *fpopts);
 
 /* Exponentiation and logarithmic functions. */
-doc_cpf_univariate(exponential, \f$ X_i = \exp(A_i) \f$, 53, 1023)
+doc_cpf_univariate(exponential, \f$ X_i = \exp(A_i) \f$, 53, 1023, -1022)
 static inline int cpf_exp(double *X, const double *A,
                           const size_t numelem, optstruct *fpopts);
 
-doc_cpf_frexp(53, 1023)
+doc_cpf_frexp(53, 1023, -1022)
 static inline int cpf_frexp(double *X, int *exp, const double *A,
                             const size_t numelem, optstruct *fpopts);
-doc_cpf_scaling(2, 53, 1023)
+doc_cpf_scaling(2, 53, 1023, -1022)
 static inline int cpf_ldexp(double *X, const double *A, const int *exp,
                             const size_t numelem, optstruct *fpopts);
-doc_cpf_univariate(natural logarithm, \f$ X_i = \log(A_i) \f$, 53, 1023)
+doc_cpf_univariate(natural logarithm, \f$ X_i = \log(A_i) \f$, 53, 1023, -1022)
 static inline int cpf_log(double *X, const double *A,
                           const size_t numelem, optstruct *fpopts);
-doc_cpf_univariate(base - 10 logarithm, \f$ X_i = \log_{10}(A_i) \f$, 53, 1023)
+doc_cpf_univariate(base - 10 logarithm, \f$ X_i = \log_{10}(A_i) \f$, 53, 1023, -1022)
 static inline int cpf_log10(double *X, const double *A,
                             const size_t numelem, optstruct *fpopts);
-doc_cpf_modf(53, 1023)
+doc_cpf_modf(53, 1023, -1022)
 static inline int cpf_modf(double *X, double *intpart, const double *A,
                            const size_t numelem, optstruct *fpopts);
-doc_cpf_univariate(base-2 exponential, \f$ X_i = 2^{A_i} \f$, 53, 1023)
+doc_cpf_univariate(base-2 exponential, \f$ X_i = 2^{A_i} \f$, 53, 1023, -1022)
 static inline int cpf_exp2(double *X, const double *A,
                            const size_t numelem, optstruct *fpopts);
-doc_cpf_univariate(exp(x) - 1, \f$ X_i = \exp(A_i) - 1 \f$, 53, 1023)
+doc_cpf_univariate(exp(x) - 1, \f$ X_i = \exp(A_i) - 1 \f$, 53, 1023, -1022)
 static inline int cpf_expm1(double *X, const double *A,
                             const size_t numelem, optstruct *fpopts);
-doc_cpf_ilogb(53, 1023)
+doc_cpf_ilogb(53, 1023, -1022)
 static inline int cpf_ilogb(int *exp, const double *A,
                             const size_t numelem, optstruct *fpopts);
 
 doc_cpf_univariate(natural logarithm of number shifted by one,
-                   \f$ X_i = \log(1+A_i) \f$, 53, 1023)
+                   \f$ X_i = \log(1+A_i) \f$, 53, 1023, -1022)
 static inline int cpf_log1p(double *X, const double *A,
                             size_t numelem, optstruct *fpopts);
-doc_cpf_univariate(base-2 logarithm, \f$ X_i = \log_2(A_i) \f$, 53, 1023)
+doc_cpf_univariate(base-2 logarithm, \f$ X_i = \log_2(A_i) \f$, 53, 1023, -1022)
 static inline int cpf_log2(double *X, const double *A,
                            const size_t numelem, optstruct *fpopts);
 doc_cpf_univariate(base-FLT_RADIX logarithm of absolute value,
-                   \f$ X_i = \log(\lvert A_i \rvert) \f$, 53, 1023)
+                   \f$ X_i = \log(\lvert A_i \rvert) \f$, 53, 1023, -1022)
 static inline int cpf_logb(double *X, const double *A,
                            const size_t numelem, optstruct *fpopts);
-doc_cpf_scaling(FLT\_RADIX, 53, 1023)
+doc_cpf_scaling(FLT\_RADIX, 53, 1023, -1022)
   static inline int cpf_scalbn(double *X, const double *A, const int *exp,
                                const size_t numelem, optstruct *fpopts);
-doc_cpf_scaling(FLT\_RADIX, 53, 1023)
+doc_cpf_scaling(FLT\_RADIX, 53, 1023, -1022)
   static inline int cpf_scalbln(double *X, const double *A,
                                 const long int *exp, const size_t numelem,
                                 optstruct *fpopts);
 
 /* Power functions. */
-doc_cpf_bivariate(real powers, \f$ X_i = A_i^{B_i} \f$, 53, 1023)
+doc_cpf_bivariate(real powers, \f$ X_i = A_i^{B_i} \f$, 53, 1023, -1022)
 static inline int cpf_pow(double *X, const double *A, const double *B,
                           const size_t numelem, optstruct *fpopts);
-doc_cpf_univariate(square root, \f$ X_i = \sqrt{A_i} \f$, 53, 1023)
+doc_cpf_univariate(square root, \f$ X_i = \sqrt{A_i} \f$, 53, 1023, -1022)
 static inline int cpf_sqrt(double *X, const double *A,
                            const size_t numelem, optstruct *fpopts);
-doc_cpf_univariate(cube root, \f$ X_i = \sqrt[3]{A_i} \f$, 53, 1023)
+doc_cpf_univariate(cube root, \f$ X_i = \sqrt[3]{A_i} \f$, 53, 1023, -1022)
 static inline int cpf_cbrt(double *X, const double *A,
                            const size_t numelem, optstruct *fpopts);
 doc_cpf_bivariate(hypotenuse of a right-angle triangle,
-                  \f$ X_i = \sqrt{A_i^2 + B_i^2} \f$, 53, 1023)
+                  \f$ X_i = \sqrt{A_i^2 + B_i^2} \f$, 53, 1023, -1022)
 static inline int cpf_hypot(double *X, const double *A, const double *B,
                             const size_t numelem, optstruct *fpopts);
 
 /* Error and gamma functions. */
-doc_cpf_univariate(error function, \f$ X_i = \mathrm{erf}(A_i) \f$, 53, 1023)
+doc_cpf_univariate(error function, \f$ X_i = \mathrm{erf}(A_i) \f$, 53, 1023, -1022)
 static inline int cpf_erf(double *X, const double *A,
                           const size_t numelem, optstruct *fpopts);
 doc_cpf_univariate(complementary error function,
-                   \f$ X_i = \mathrm{erfc}(A_i) \f$, 53, 1023)
+                   \f$ X_i = \mathrm{erfc}(A_i) \f$, 53, 1023, -1022)
 static inline int cpf_erfc(double *X, const double *A,
                            const size_t numelem, optstruct *fpopts);
-doc_cpf_univariate(gamma function, \f$ X_i = \Gamma(A_i) \f$, 53, 1023)
+doc_cpf_univariate(gamma function, \f$ X_i = \Gamma(A_i) \f$, 53, 1023, -1022)
 static inline int cpf_tgamma(double *X, const double *A,
                              const size_t numelem, optstruct *fpopts);
 doc_cpf_univariate(natural logarithm of absolute value of gamma function,
-                   \f$ X_i = \log(\lvert \Gamma(A_i) \rvert) \f$, 53, 1023)
+                   \f$ X_i = \log(\lvert \Gamma(A_i) \rvert) \f$, 53, 1023, -1022)
 static inline int cpf_lgamma(double *X, const double *A,
                              const size_t numelem, optstruct *fpopts);
 
 /* Rounding and remainder functions. */
-doc_cpf_univariate(ceiling function, \f$ X_i = \lceil A_i \rceil \f$, 53, 1023)
+doc_cpf_univariate(ceiling function, \f$ X_i = \lceil A_i \rceil \f$, 53, 1023, -1022)
 static inline int cpf_ceil(double *X, const double *A,
                            const size_t numelem, optstruct *fpopts);
-doc_cpf_univariate(floor function, \f$ X_i = \lfloor A_i \rfloor \f$, 53, 1023)
+doc_cpf_univariate(floor function, \f$ X_i = \lfloor A_i \rfloor \f$, 53, 1023, -1022)
 static inline int cpf_floor(double *X, const double *A,
                             const size_t numelem, optstruct *fpopts);
 doc_cpf_bivariate(floating-point remainder of division,
-                  \f$ X_i = A_i \;\mathrm{mod}\; B_i \f$, 53, 1023)
+                  \f$ X_i = A_i \;\mathrm{mod}\; B_i \f$, 53, 1023, -1022)
 static inline int cpf_fmod(double *X, const double *A, const double *B,
                            const size_t numelem, optstruct *fpopts);
 doc_cpf_univariate(integer truncation, \f$ X_i = \mathrm{trunc}(A_i) \f$,
-                   53, 1023)
+                   53, 1023, -1022)
 static inline int cpf_trunc(double *X, const double *A,
                             const size_t numelem, optstruct *fpopts);
 
 doc_cpf_univariate(closest integer (with round-to-nearest),
-                   \f$ X_i = \mathrm{round}(A_i) \f$, 53, 1023)
+                   \f$ X_i = \mathrm{round}(A_i) \f$, 53, 1023, -1022)
 static inline int cpf_round(double *X, const double *A,
                             const size_t numelem, optstruct *fpopts);
 doc_cpf_univariate(closest integer (with round-to-nearest),
-                   \f$ X_i = \mathrm{round}(A_i) \f$, 53, 1023)
+                   \f$ X_i = \mathrm{round}(A_i) \f$, 53, 1023, -1022)
 static inline int cpf_lround(long *X, const double *A,
                              const size_t numelem, optstruct *fpopts);
 doc_cpf_univariate_nobitflip(closest integer (with round-to-nearest),
-                             \f$ X_i = \mathrm{round}(A_i) \f$, 53, 1023)
+                             \f$ X_i = \mathrm{round}(A_i) \f$, 53, 1023, -1022)
 static inline int cpf_llround(long long *X, const double *A,
                               const size_t numelem, optstruct *fpopts);
 
-doc_cpf_rint(PMAX, EMAX)
+doc_cpf_rint(53, 1023, -1022)
 static inline int cpf_rint(double *X, int *exception, const double *A,
                            const size_t numelem, optstruct *fpopts);
-doc_cpf_rint(PMAX, EMAX)
+doc_cpf_rint(53, 1023, -1022)
 static inline int cpf_lrint(long *X, int *exception, const double *A,
                             const size_t numelem, optstruct *fpopts);
-doc_cpf_rint(PMAX, EMAX)
+doc_cpf_rint(53, 1023, -1022)
 static inline int cpf_llrint(long long *X, int *exception, const double *A,
                              const size_t numelem, optstruct *fpopts);
-doc_cpf_nearbyint(PMAX, EMAX)
+doc_cpf_nearbyint(53, 1023, -1022)
 static inline int cpf_nearbyint(double *X, const double *A,
                                 const size_t numelem, optstruct *fpopts);
 doc_cpf_bivariate(remainder of the floating point division,
                   \f$ X_i = A_i^2 - k \times B_i \f$
                   for largest \f$ k \f$ such that \f$ k \times B_i < A_i \f$,
-                  53, 1023)
+                  53, 1023, -1022)
 static inline int cpf_remainder(double *X, const double *A, const double *B,
                                 const size_t numelem, optstruct *fpopts);
 
-doc_cpf_remquo(PMAX, EMAX)
+doc_cpf_remquo(53, 1023, -1022)
 static inline int cpf_remquo(double *X, int *quot,
                              const double *A, const double *B,
                              const size_t numelem, optstruct *fpopts);
 
 /* Floating-point manipulation functions. */
 doc_cpf_bivariate(number from magnitude and sign,
-                  \f$ X_i = \mathrm{sign}(A_i) * abs(B_i) \f$, 53, 1023)
+                  \f$ X_i = \mathrm{sign}(A_i) * abs(B_i) \f$, 53, 1023, -1022)
 static inline int cpf_copysign(double *X, const double *A, const double *B,
                                const size_t numelem, optstruct *fpopts);
 doc_cpf_bivariate(next floating-point number in specified direction,
                   the floating-point number closest to \f$ A_i \f$ in the
-                  direction of \f$ B_i \f$, 53, 1023)
+                  direction of \f$ B_i \f$, 53, 1023, -1022)
 static inline int cpf_nextafter(double *X, const double *A, const double *B,
                                 const size_t numelem, optstruct *fpopts);
 doc_cpf_bivariate(next floating-point number in specified direction,
                   the floating-point number closest to \f$ A_i \f$ in the
-                  direction of \f$ B_i \f$, 53, 1023)
+                  direction of \f$ B_i \f$, 53, 1023, -1022)
 static inline int cpf_nexttoward(double *X, const double *A,
                                  const long double *B, const size_t numelem,
                                  optstruct *fpopts);
 
 /* Minimum, maximum, difference functions. */
 doc_cpf_bivariate(positive difference, \f$ X_i = \lvert A_i \rvert - B_i \f$,
-                  53, 1023)
+                  53, 1023, -1022)
 static inline int cpf_fdim(double *X, const double *A, const double *B,
                            const size_t numelem, optstruct *fpopts);
 doc_cpf_bivariate(element-wise maximum, \f$ X_i = \mathrm{max}(A_i, B_i) \f$,
-                  53, 1023)
+                  53, 1023, -1022)
 static inline int cpf_fmax(double *X, const double *A, const double *B,
                            const size_t numelem, optstruct *fpopts);
 doc_cpf_bivariate(element-wise minimum, \f$ X_i = \mathrm{min}(A_i, B_i) \f$,
-                  53, 1023)
+                  53, 1023, -1022)
 static inline int cpf_fmin(double *X, const double *A, const double *B,
                            const size_t numelem, optstruct *fpopts);
 
 /* Classification. */
-doc_cpf_fpclassify(53, 1023)
+doc_cpf_fpclassify(53, 1023, -1022)
 static inline int cpf_fpclassify(int *r, const double *A,
                                  const size_t numelem, optstruct *fpopts);
-doc_cpf_isfun(finite, 53, 1023)
+doc_cpf_isfun(finite, 53, 1023, -1022)
 static inline int cpf_isfinite(int *r, const double *A,
                                const size_t numelem, optstruct *fpopts);
-doc_cpf_isfun(infinite, 53, 1023)
+doc_cpf_isfun(infinite, 53, 1023, -1022)
 static inline int cpf_isinf(int *r, const double *A,
                             const size_t numelem, optstruct *fpopts);
-doc_cpf_isfun(not a number, 53, 1023)
+doc_cpf_isfun(not a number, 53, 1023, -1022)
 static inline int cpf_isnan(int *r, const double *A,
                             const size_t numelem, optstruct *fpopts);
-doc_cpf_isfun(normal, 53, 1023)
+doc_cpf_isfun(normal, 53, 1023, -1022)
 static inline int cpf_isnormal(int *r, const double *A,
                                const size_t numelem, optstruct *fpopts);
 
 /* Other functions. */
-doc_cpf_univariate(absolute value, \f$ X_i = \lvert A_i \rvert \f$, 53, 1023)
+doc_cpf_univariate(absolute value, \f$ X_i = \lvert A_i \rvert \f$, 53, 1023, -1022)
 static inline int cpf_fabs(double *X, const double *A,
                            const size_t numelem, optstruct *fpopts);
 doc_cpf_trivariate(fused multiply-add , \f$ X_i = A_i \times B_i + C_i \f$,
-                   53, 1023)
+                   53, 1023, -1022)
 static inline int cpf_fma(double *X, const double *A, const double *B,
                           const double *C, const size_t numelem,
                           optstruct *fpopts);

--- a/src/cpfloat_binary64.h
+++ b/src/cpfloat_binary64.h
@@ -13,272 +13,272 @@
 #include "cpfloat_docmacros.h"
 
 /* Validation of floating-point parameters. */
-doc_cpfloat_validate_optstruct(double, 26, 53, 1023, -1022)
+doc_cpfloat_validate_optstruct(double, 26, 53, -1022, 1023)
 static inline int cpfloat_validate_optstruct(const optstruct *fpopts);
 
 /* Rounding functions. */
-doc_cpfloat(double, 53, 1023, -1022)
+doc_cpfloat(double, 53, -1022, 1023)
 static inline int cpfloat(double *X, const double *A, const size_t numelem,
                           optstruct *fpopts);
-doc_cpfloat(double, 53, 1023, -1022)
+doc_cpfloat(double, 53, -1022, 1023)
 static inline int cpf_fpround(double *X, const double *A,
                               const size_t numelem, optstruct *fpopts);
 
 /* Elementary arithmetic operations. */
-doc_cpf_bivariate(sum, \f$ X_i = A_i + B_i \f$, 53, 1023, -1022)
+doc_cpf_bivariate(sum, \f$ X_i = A_i + B_i \f$, 53, -1022, 1023)
 static inline int cpf_add(double *X, const double *A, const double *B,
                           const size_t numelem, optstruct *fpopts);
-doc_cpf_bivariate(difference, \f$ X_i = A_i - B_i \f$, 53, 1023, -1022)
+doc_cpf_bivariate(difference, \f$ X_i = A_i - B_i \f$, 53, -1022, 1023)
 static inline int cpf_sub(double *X, const double *A, const double *B,
                           const size_t numelem, optstruct *fpopts);
-doc_cpf_bivariate(product, \f$ X_i = A_i \times B_i \f$, 53, 1023, -1022)
+doc_cpf_bivariate(product, \f$ X_i = A_i \times B_i \f$, 53, -1022, 1023)
 static inline int cpf_mul(double *X, const double *A, const double *B,
                           const size_t numelem, optstruct *fpopts);
-doc_cpf_bivariate(ratio, \f$ X_i = A_i / B_i \f$, 53, 1023, -1022)
+doc_cpf_bivariate(ratio, \f$ X_i = A_i / B_i \f$, 53, -1022, 1023)
 static inline int cpf_div(double *X, const double *A, const double *B,
                           const size_t numelem, optstruct *fpopts);
 
 /* Trigonometric functions. */
-doc_cpf_univariate(trigonometric cosine, \f$ X_i = \cos(A_i) \f$, 53, 1023, -1022)
+doc_cpf_univariate(trigonometric cosine, \f$ X_i = \cos(A_i) \f$, 53, -1022, 1023)
 static inline int cpf_cos(double *X, const double *A,
                           const size_t numelem, optstruct *fpopts);
-doc_cpf_univariate(trigonometric sine, \f$ X_i = \sin(A_i) \f$, 53, 1023, -1022)
+doc_cpf_univariate(trigonometric sine, \f$ X_i = \sin(A_i) \f$, 53, -1022, 1023)
 static inline int cpf_sin(double *X, const double *A,
                           const size_t numelem, optstruct *fpopts);
-doc_cpf_univariate(trigonometric tangent, \f$ X_i = \tan(A_i) \f$, 53, 1023, -1022)
+doc_cpf_univariate(trigonometric tangent, \f$ X_i = \tan(A_i) \f$, 53, -1022, 1023)
 static inline int cpf_tan(double *X, const double *A,
                           const size_t numelem, optstruct *fpopts);
 
 doc_cpf_univariate(inverse trigonometric cosine,
-                   \f$ X_i = \mathrm{acos(A_i)} \f$, 53, 1023, -1022)
+                   \f$ X_i = \mathrm{acos(A_i)} \f$, 53, -1022, 1023)
 static inline int cpf_acos(double *X, const double *A,
                            const size_t numelem, optstruct *fpopts);
 doc_cpf_univariate(inverse trigonometric sine,
-                   \f$ X_i = \mathrm{asin}(A_i) \f$, 53, 1023, -1022)
+                   \f$ X_i = \mathrm{asin}(A_i) \f$, 53, -1022, 1023)
 static inline int cpf_asin(double *X, const double *A,
                            const size_t numelem, optstruct *fpopts);
 doc_cpf_univariate(inverse trigonometric tangent,
-                   \f$ X_i = \mathrm{atan}(A_i) \f$, 53, 1023, -1022)
+                   \f$ X_i = \mathrm{atan}(A_i) \f$, 53, -1022, 1023)
 static inline int cpf_atan(double *X, const double *A,
                            const size_t numelem, optstruct *fpopts);
 doc_cpf_bivariate(2-argument arctangent,
-                  \f$ X_i = \mathrm{atan}(B_i / A_i) \f$, 53, 1023, -1022)
+                  \f$ X_i = \mathrm{atan}(B_i / A_i) \f$, 53, -1022, 1023)
 static inline int cpf_atan2(double *X, const double *A, const double *B,
                             const size_t numelem, optstruct *fpopts);
 
 /* Hyperbolic functions. */
 doc_cpf_univariate(hyperbolic cosine, \f$ X_i = \mathrm{cosh}(A_i) \f$,
-                   53, 1023, -1022)
+                   53, -1022, 1023)
 static inline int cpf_cosh(double *X, const double *A,
                            const size_t numelem, optstruct *fpopts);
-doc_cpf_univariate(hyperbolic sine, \f$ X_i = \mathrm{sinh}(A_i) \f$, 53, 1023, -1022)
+doc_cpf_univariate(hyperbolic sine, \f$ X_i = \mathrm{sinh}(A_i) \f$, 53, -1022, 1023)
 static inline int cpf_sinh(double *X, const double *A,
                            const size_t numelem, optstruct *fpopts);
 doc_cpf_univariate(hyperbolic tangent , \f$ X_i = \mathrm{tanh}(A_i) \f$,
-                   53, 1023, -1022)
+                   53, -1022, 1023)
 static inline int cpf_tanh(double *X, const double *A,
                            const size_t numelem, optstruct *fpopts);
 
 doc_cpf_univariate(inverse hyperbolic cosine,
-                   \f$ X_i = \mathrm{arcosh}(A_i) \f$, 53, 1023, -1022)
+                   \f$ X_i = \mathrm{arcosh}(A_i) \f$, 53, -1022, 1023)
 static inline int cpf_acosh(double *X, const double *A,
                             const size_t numelem, optstruct *fpopts);
 doc_cpf_univariate(inverse hyperbolic sine,
-                   \f$ X_i = \mathrm{arsinh}(A_i) \f$, 53, 1023, -1022)
+                   \f$ X_i = \mathrm{arsinh}(A_i) \f$, 53, -1022, 1023)
 static inline int cpf_asinh(double *X, const double *A,
                             const size_t numelem, optstruct *fpopts);
 doc_cpf_univariate(inverse hyperbolic tangent,
-                   \f$ X_i = \mathrm{artanh}(A_i) \f$, 53, 1023, -1022)
+                   \f$ X_i = \mathrm{artanh}(A_i) \f$, 53, -1022, 1023)
 static inline int cpf_atanh(double *X, const double *A,
                             const size_t numelem, optstruct *fpopts);
 
 /* Exponentiation and logarithmic functions. */
-doc_cpf_univariate(exponential, \f$ X_i = \exp(A_i) \f$, 53, 1023, -1022)
+doc_cpf_univariate(exponential, \f$ X_i = \exp(A_i) \f$, 53, -1022, 1023)
 static inline int cpf_exp(double *X, const double *A,
                           const size_t numelem, optstruct *fpopts);
 
-doc_cpf_frexp(53, 1023, -1022)
+doc_cpf_frexp(53, -1022, 1023)
 static inline int cpf_frexp(double *X, int *exp, const double *A,
                             const size_t numelem, optstruct *fpopts);
-doc_cpf_scaling(2, 53, 1023, -1022)
+doc_cpf_scaling(2, 53, -1022, 1023)
 static inline int cpf_ldexp(double *X, const double *A, const int *exp,
                             const size_t numelem, optstruct *fpopts);
-doc_cpf_univariate(natural logarithm, \f$ X_i = \log(A_i) \f$, 53, 1023, -1022)
+doc_cpf_univariate(natural logarithm, \f$ X_i = \log(A_i) \f$, 53, -1022, 1023)
 static inline int cpf_log(double *X, const double *A,
                           const size_t numelem, optstruct *fpopts);
-doc_cpf_univariate(base - 10 logarithm, \f$ X_i = \log_{10}(A_i) \f$, 53, 1023, -1022)
+doc_cpf_univariate(base - 10 logarithm, \f$ X_i = \log_{10}(A_i) \f$, 53, -1022, 1023)
 static inline int cpf_log10(double *X, const double *A,
                             const size_t numelem, optstruct *fpopts);
-doc_cpf_modf(53, 1023, -1022)
+doc_cpf_modf(53, -1022, 1023)
 static inline int cpf_modf(double *X, double *intpart, const double *A,
                            const size_t numelem, optstruct *fpopts);
-doc_cpf_univariate(base-2 exponential, \f$ X_i = 2^{A_i} \f$, 53, 1023, -1022)
+doc_cpf_univariate(base-2 exponential, \f$ X_i = 2^{A_i} \f$, 53, -1022, 1023)
 static inline int cpf_exp2(double *X, const double *A,
                            const size_t numelem, optstruct *fpopts);
-doc_cpf_univariate(exp(x) - 1, \f$ X_i = \exp(A_i) - 1 \f$, 53, 1023, -1022)
+doc_cpf_univariate(exp(x) - 1, \f$ X_i = \exp(A_i) - 1 \f$, 53, -1022, 1023)
 static inline int cpf_expm1(double *X, const double *A,
                             const size_t numelem, optstruct *fpopts);
-doc_cpf_ilogb(53, 1023, -1022)
+doc_cpf_ilogb(53, -1022, 1023)
 static inline int cpf_ilogb(int *exp, const double *A,
                             const size_t numelem, optstruct *fpopts);
 
 doc_cpf_univariate(natural logarithm of number shifted by one,
-                   \f$ X_i = \log(1+A_i) \f$, 53, 1023, -1022)
+                   \f$ X_i = \log(1+A_i) \f$, 53, -1022, 1023)
 static inline int cpf_log1p(double *X, const double *A,
                             size_t numelem, optstruct *fpopts);
-doc_cpf_univariate(base-2 logarithm, \f$ X_i = \log_2(A_i) \f$, 53, 1023, -1022)
+doc_cpf_univariate(base-2 logarithm, \f$ X_i = \log_2(A_i) \f$, 53, -1022, 1023)
 static inline int cpf_log2(double *X, const double *A,
                            const size_t numelem, optstruct *fpopts);
 doc_cpf_univariate(base-FLT_RADIX logarithm of absolute value,
-                   \f$ X_i = \log(\lvert A_i \rvert) \f$, 53, 1023, -1022)
+                   \f$ X_i = \log(\lvert A_i \rvert) \f$, 53, -1022, 1023)
 static inline int cpf_logb(double *X, const double *A,
                            const size_t numelem, optstruct *fpopts);
-doc_cpf_scaling(FLT\_RADIX, 53, 1023, -1022)
+doc_cpf_scaling(FLT\_RADIX, 53, -1022, 1023)
   static inline int cpf_scalbn(double *X, const double *A, const int *exp,
                                const size_t numelem, optstruct *fpopts);
-doc_cpf_scaling(FLT\_RADIX, 53, 1023, -1022)
+doc_cpf_scaling(FLT\_RADIX, 53, -1022, 1023)
   static inline int cpf_scalbln(double *X, const double *A,
                                 const long int *exp, const size_t numelem,
                                 optstruct *fpopts);
 
 /* Power functions. */
-doc_cpf_bivariate(real powers, \f$ X_i = A_i^{B_i} \f$, 53, 1023, -1022)
+doc_cpf_bivariate(real powers, \f$ X_i = A_i^{B_i} \f$, 53, -1022, 1023)
 static inline int cpf_pow(double *X, const double *A, const double *B,
                           const size_t numelem, optstruct *fpopts);
-doc_cpf_univariate(square root, \f$ X_i = \sqrt{A_i} \f$, 53, 1023, -1022)
+doc_cpf_univariate(square root, \f$ X_i = \sqrt{A_i} \f$, 53, -1022, 1023)
 static inline int cpf_sqrt(double *X, const double *A,
                            const size_t numelem, optstruct *fpopts);
-doc_cpf_univariate(cube root, \f$ X_i = \sqrt[3]{A_i} \f$, 53, 1023, -1022)
+doc_cpf_univariate(cube root, \f$ X_i = \sqrt[3]{A_i} \f$, 53, -1022, 1023)
 static inline int cpf_cbrt(double *X, const double *A,
                            const size_t numelem, optstruct *fpopts);
 doc_cpf_bivariate(hypotenuse of a right-angle triangle,
-                  \f$ X_i = \sqrt{A_i^2 + B_i^2} \f$, 53, 1023, -1022)
+                  \f$ X_i = \sqrt{A_i^2 + B_i^2} \f$, 53, -1022, 1023)
 static inline int cpf_hypot(double *X, const double *A, const double *B,
                             const size_t numelem, optstruct *fpopts);
 
 /* Error and gamma functions. */
-doc_cpf_univariate(error function, \f$ X_i = \mathrm{erf}(A_i) \f$, 53, 1023, -1022)
+doc_cpf_univariate(error function, \f$ X_i = \mathrm{erf}(A_i) \f$, 53, -1022, 1023)
 static inline int cpf_erf(double *X, const double *A,
                           const size_t numelem, optstruct *fpopts);
 doc_cpf_univariate(complementary error function,
-                   \f$ X_i = \mathrm{erfc}(A_i) \f$, 53, 1023, -1022)
+                   \f$ X_i = \mathrm{erfc}(A_i) \f$, 53, -1022, 1023)
 static inline int cpf_erfc(double *X, const double *A,
                            const size_t numelem, optstruct *fpopts);
-doc_cpf_univariate(gamma function, \f$ X_i = \Gamma(A_i) \f$, 53, 1023, -1022)
+doc_cpf_univariate(gamma function, \f$ X_i = \Gamma(A_i) \f$, 53, -1022, 1023)
 static inline int cpf_tgamma(double *X, const double *A,
                              const size_t numelem, optstruct *fpopts);
 doc_cpf_univariate(natural logarithm of absolute value of gamma function,
-                   \f$ X_i = \log(\lvert \Gamma(A_i) \rvert) \f$, 53, 1023, -1022)
+                   \f$ X_i = \log(\lvert \Gamma(A_i) \rvert) \f$, 53, -1022, 1023)
 static inline int cpf_lgamma(double *X, const double *A,
                              const size_t numelem, optstruct *fpopts);
 
 /* Rounding and remainder functions. */
-doc_cpf_univariate(ceiling function, \f$ X_i = \lceil A_i \rceil \f$, 53, 1023, -1022)
+doc_cpf_univariate(ceiling function, \f$ X_i = \lceil A_i \rceil \f$, 53, -1022, 1023)
 static inline int cpf_ceil(double *X, const double *A,
                            const size_t numelem, optstruct *fpopts);
-doc_cpf_univariate(floor function, \f$ X_i = \lfloor A_i \rfloor \f$, 53, 1023, -1022)
+doc_cpf_univariate(floor function, \f$ X_i = \lfloor A_i \rfloor \f$, 53, -1022, 1023)
 static inline int cpf_floor(double *X, const double *A,
                             const size_t numelem, optstruct *fpopts);
 doc_cpf_bivariate(floating-point remainder of division,
-                  \f$ X_i = A_i \;\mathrm{mod}\; B_i \f$, 53, 1023, -1022)
+                  \f$ X_i = A_i \;\mathrm{mod}\; B_i \f$, 53, -1022, 1023)
 static inline int cpf_fmod(double *X, const double *A, const double *B,
                            const size_t numelem, optstruct *fpopts);
 doc_cpf_univariate(integer truncation, \f$ X_i = \mathrm{trunc}(A_i) \f$,
-                   53, 1023, -1022)
+                   53, -1022, 1023)
 static inline int cpf_trunc(double *X, const double *A,
                             const size_t numelem, optstruct *fpopts);
 
 doc_cpf_univariate(closest integer (with round-to-nearest),
-                   \f$ X_i = \mathrm{round}(A_i) \f$, 53, 1023, -1022)
+                   \f$ X_i = \mathrm{round}(A_i) \f$, 53, -1022, 1023)
 static inline int cpf_round(double *X, const double *A,
                             const size_t numelem, optstruct *fpopts);
 doc_cpf_univariate(closest integer (with round-to-nearest),
-                   \f$ X_i = \mathrm{round}(A_i) \f$, 53, 1023, -1022)
+                   \f$ X_i = \mathrm{round}(A_i) \f$, 53, -1022, 1023)
 static inline int cpf_lround(long *X, const double *A,
                              const size_t numelem, optstruct *fpopts);
 doc_cpf_univariate_nobitflip(closest integer (with round-to-nearest),
-                             \f$ X_i = \mathrm{round}(A_i) \f$, 53, 1023, -1022)
+                             \f$ X_i = \mathrm{round}(A_i) \f$, 53, -1022, 1023)
 static inline int cpf_llround(long long *X, const double *A,
                               const size_t numelem, optstruct *fpopts);
 
-doc_cpf_rint(53, 1023, -1022)
+doc_cpf_rint(53, -1022, 1023)
 static inline int cpf_rint(double *X, int *exception, const double *A,
                            const size_t numelem, optstruct *fpopts);
-doc_cpf_rint(53, 1023, -1022)
+doc_cpf_rint(53, -1022, 1023)
 static inline int cpf_lrint(long *X, int *exception, const double *A,
                             const size_t numelem, optstruct *fpopts);
-doc_cpf_rint(53, 1023, -1022)
+doc_cpf_rint(53, -1022, 1023)
 static inline int cpf_llrint(long long *X, int *exception, const double *A,
                              const size_t numelem, optstruct *fpopts);
-doc_cpf_nearbyint(53, 1023, -1022)
+doc_cpf_nearbyint(53, -1022, 1023)
 static inline int cpf_nearbyint(double *X, const double *A,
                                 const size_t numelem, optstruct *fpopts);
 doc_cpf_bivariate(remainder of the floating point division,
                   \f$ X_i = A_i^2 - k \times B_i \f$
                   for largest \f$ k \f$ such that \f$ k \times B_i < A_i \f$,
-                  53, 1023, -1022)
+                  53, -1022, 1023)
 static inline int cpf_remainder(double *X, const double *A, const double *B,
                                 const size_t numelem, optstruct *fpopts);
 
-doc_cpf_remquo(53, 1023, -1022)
+doc_cpf_remquo(53, -1022, 1023)
 static inline int cpf_remquo(double *X, int *quot,
                              const double *A, const double *B,
                              const size_t numelem, optstruct *fpopts);
 
 /* Floating-point manipulation functions. */
 doc_cpf_bivariate(number from magnitude and sign,
-                  \f$ X_i = \mathrm{sign}(A_i) * abs(B_i) \f$, 53, 1023, -1022)
+                  \f$ X_i = \mathrm{sign}(A_i) * abs(B_i) \f$, 53, -1022, 1023)
 static inline int cpf_copysign(double *X, const double *A, const double *B,
                                const size_t numelem, optstruct *fpopts);
 doc_cpf_bivariate(next floating-point number in specified direction,
                   the floating-point number closest to \f$ A_i \f$ in the
-                  direction of \f$ B_i \f$, 53, 1023, -1022)
+                  direction of \f$ B_i \f$, 53, -1022, 1023)
 static inline int cpf_nextafter(double *X, const double *A, const double *B,
                                 const size_t numelem, optstruct *fpopts);
 doc_cpf_bivariate(next floating-point number in specified direction,
                   the floating-point number closest to \f$ A_i \f$ in the
-                  direction of \f$ B_i \f$, 53, 1023, -1022)
+                  direction of \f$ B_i \f$, 53, -1022, 1023)
 static inline int cpf_nexttoward(double *X, const double *A,
                                  const long double *B, const size_t numelem,
                                  optstruct *fpopts);
 
 /* Minimum, maximum, difference functions. */
 doc_cpf_bivariate(positive difference, \f$ X_i = \lvert A_i \rvert - B_i \f$,
-                  53, 1023, -1022)
+                  53, -1022, 1023)
 static inline int cpf_fdim(double *X, const double *A, const double *B,
                            const size_t numelem, optstruct *fpopts);
 doc_cpf_bivariate(element-wise maximum, \f$ X_i = \mathrm{max}(A_i, B_i) \f$,
-                  53, 1023, -1022)
+                  53, -1022, 1023)
 static inline int cpf_fmax(double *X, const double *A, const double *B,
                            const size_t numelem, optstruct *fpopts);
 doc_cpf_bivariate(element-wise minimum, \f$ X_i = \mathrm{min}(A_i, B_i) \f$,
-                  53, 1023, -1022)
+                  53, -1022, 1023)
 static inline int cpf_fmin(double *X, const double *A, const double *B,
                            const size_t numelem, optstruct *fpopts);
 
 /* Classification. */
-doc_cpf_fpclassify(53, 1023, -1022)
+doc_cpf_fpclassify(53, -1022, 1023)
 static inline int cpf_fpclassify(int *r, const double *A,
                                  const size_t numelem, optstruct *fpopts);
-doc_cpf_isfun(finite, 53, 1023, -1022)
+doc_cpf_isfun(finite, 53, -1022, 1023)
 static inline int cpf_isfinite(int *r, const double *A,
                                const size_t numelem, optstruct *fpopts);
-doc_cpf_isfun(infinite, 53, 1023, -1022)
+doc_cpf_isfun(infinite, 53, -1022, 1023)
 static inline int cpf_isinf(int *r, const double *A,
                             const size_t numelem, optstruct *fpopts);
-doc_cpf_isfun(not a number, 53, 1023, -1022)
+doc_cpf_isfun(not a number, 53, -1022, 1023)
 static inline int cpf_isnan(int *r, const double *A,
                             const size_t numelem, optstruct *fpopts);
-doc_cpf_isfun(normal, 53, 1023, -1022)
+doc_cpf_isfun(normal, 53, -1022, 1023)
 static inline int cpf_isnormal(int *r, const double *A,
                                const size_t numelem, optstruct *fpopts);
 
 /* Other functions. */
-doc_cpf_univariate(absolute value, \f$ X_i = \lvert A_i \rvert \f$, 53, 1023, -1022)
+doc_cpf_univariate(absolute value, \f$ X_i = \lvert A_i \rvert \f$, 53, -1022, 1023)
 static inline int cpf_fabs(double *X, const double *A,
                            const size_t numelem, optstruct *fpopts);
 doc_cpf_trivariate(fused multiply-add , \f$ X_i = A_i \times B_i + C_i \f$,
-                   53, 1023, -1022)
+                   53, -1022, 1023)
 static inline int cpf_fma(double *X, const double *A, const double *B,
                           const double *C, const size_t numelem,
                           optstruct *fpopts);

--- a/src/cpfloat_definitions.h
+++ b/src/cpfloat_definitions.h
@@ -203,6 +203,19 @@ typedef struct {
    */
   cpfloat_exponent_t emax;
   /**
+   * @brief Minimum exponent of target format.
+   *
+   * @details The minimum values allowed are -126 and -1022 if the storage format
+   * is `float` or `double`, respectively. Smaller values are increase to the
+   * minimum allowed value without warning. This field is ignored unless
+   * `explim` is set to `CPFLOAT_EXPRANGE_TARG`.
+   *
+   * The validation functions cpfloatf_validate_optstruct() and
+   * cpfloat_validate_optstruct() return an error code if the required minimum
+   * exponent is smaller than the minimum allowed by the storage format.
+   */
+  cpfloat_exponent_t emin;
+  /**
    * @brief Support for subnormal numbers in target format.
    *
    * @details Subnormal numbers are supported if this field is set to

--- a/src/cpfloat_definitions.h
+++ b/src/cpfloat_definitions.h
@@ -193,9 +193,9 @@ typedef struct {
    * @brief Maximum exponent of target format.
    *
    * @details The maximum values allowed are 127 and 1023 if the storage format
-   * is `float` or `double`, respectively. Larger values are reduced to the
-   * maximum allowed value without warning. This field is ignored unless
-   * `explim` is set to `CPFLOAT_EXPRANGE_TARG`.
+   * is `float` or `double`, respectively. If a larger value is chosen, it is
+   * changed to the maximum allowed value without warning. This field is ignored
+   * unless `explim` is set to `CPFLOAT_EXPRANGE_TARG`.
    *
    * The validation functions cpfloatf_validate_optstruct() and
    * cpfloat_validate_optstruct() return an error code if the required maximum
@@ -206,9 +206,9 @@ typedef struct {
    * @brief Minimum exponent of target format.
    *
    * @details The minimum values allowed are -126 and -1022 if the storage format
-   * is `float` or `double`, respectively. Smaller values are increase to the
-   * minimum allowed value without warning. This field is ignored unless
-   * `explim` is set to `CPFLOAT_EXPRANGE_TARG`.
+   * is `float` or `double`, respectively. If a smaller value is chosen, it is
+   * changed to the minimum allowed value without warning. This field is ignored
+   * unless `explim` is set to `CPFLOAT_EXPRANGE_TARG`.
    *
    * The validation functions cpfloatf_validate_optstruct() and
    * cpfloat_validate_optstruct() return an error code if the required minimum

--- a/src/cpfloat_docmacros.h
+++ b/src/cpfloat_docmacros.h
@@ -45,7 +45,7 @@
  given in the list above. \
  */
 
-#define doc_cpfloat(FPTYPE, PMAX, EMAX) \
+#define doc_cpfloat(FPTYPE, PMAX, EMAX, EMIN) \
 /** \
  @brief Round `FPTYPE` array to lower precision. \
  \
@@ -69,7 +69,7 @@
  than EMIN, and @b 0 otherwise. \
  */
 
-#define doc_cpf_univariate(MATHFUN, FUNSTRING, PMAX, EMAX) \
+#define doc_cpf_univariate(MATHFUN, FUNSTRING, PMAX, EMAX, EMIN) \
 /** \
  @brief Compute MATHFUN rounded to lower precision. \
  \
@@ -93,7 +93,7 @@
  than EMIN, and @b 0 otherwise. \
 */
 
-#define doc_cpf_univariate_nobitflip(MATHFUN, FUNSTRING, PMAX, EMAX) \
+#define doc_cpf_univariate_nobitflip(MATHFUN, FUNSTRING, PMAX, EMAX, EMIN) \
 /** \
  @brief Compute MATHFUN in lower precision. \
  \
@@ -116,7 +116,7 @@
  than EMIN, and @b 0 otherwise. \
 */
 
-#define doc_cpf_bivariate(MATHFUN, FUNSTRING, PMAX, EMAX) \
+#define doc_cpf_bivariate(MATHFUN, FUNSTRING, PMAX, EMAX, EMIN) \
 /** \
  @brief Compute MATHFUN in lower precision. \
  \
@@ -141,7 +141,7 @@
  than EMIN, and @b 0 otherwise. \
 */
 
-#define doc_cpf_trivariate(MATHFUN, FUNSTRING, PMAX, EMAX) \
+#define doc_cpf_trivariate(MATHFUN, FUNSTRING, PMAX, EMAX, EMIN) \
 /** \
  @brief Compute MATHFUN in lower precision. \
  \
@@ -167,7 +167,7 @@
  than EMIN, and @b 0 otherwise. \
 */
 
-#define doc_cpf_frexp(PMAX, EMAX) \
+#define doc_cpf_frexp(PMAX, EMAX, EMIN) \
 /** \
  @brief Exponent and normalized fraction of rounded floating-point number. \
  \
@@ -199,7 +199,7 @@
  than EMIN, and @b 0 otherwise. \
 */
 
-#define doc_cpf_scaling(BASE, PMAX, EMAX) \
+#define doc_cpf_scaling(BASE, PMAX, EMAX, EMIN) \
 /** \
  @brief Scale number by power of BASE in lower precision. \
  \
@@ -224,7 +224,7 @@
  than EMIN, and @b 0 otherwise. \
 */
 
-#define doc_cpf_modf(PMAX, EMAX) \
+#define doc_cpf_modf(PMAX, EMAX, EMIN) \
 /** \
  @brief Compute integral and fractional part. \
  \
@@ -250,7 +250,7 @@
  than EMIN, and @b 0 otherwise. \
 */
 
-#define doc_cpf_ilogb(PMAX, EMAX) \
+#define doc_cpf_ilogb(PMAX, EMAX, EMIN) \
 /** \
  @brief Compute integral part of the logarithm of the absolute value. \
  \
@@ -275,7 +275,7 @@
  than EMIN, and @b 0 otherwise. \
 */
 
-#define doc_cpf_rint(PMAX, EMAX) \
+#define doc_cpf_rint(PMAX, EMAX, EMIN) \
 /** \
  @brief Compute the closest integer with specified rounding mode. \
  \
@@ -301,7 +301,7 @@
  than EMIN, and @b 0 otherwise. \
 */
 
-#define doc_cpf_nearbyint(PMAX, EMAX) \
+#define doc_cpf_nearbyint(PMAX, EMAX, EMIN) \
 /** \
  @brief Compute the closest integer with specified rounding mode. \
  \
@@ -326,7 +326,7 @@
 */
 
 
-#define doc_cpf_remquo(PMAX, EMAX) \
+#define doc_cpf_remquo(PMAX, EMAX, EMIN) \
 /** \
  @brief Compute reminder and quotient of rounded numbers. \
  \
@@ -353,7 +353,7 @@
  than EMIN, and @b 0 otherwise. \
 */
 
-#define doc_cpf_fpclassify(PMAX, EMAX) \
+#define doc_cpf_fpclassify(PMAX, EMAX, EMIN) \
 /** \
  @brief Categorize floating-point values. \
  \
@@ -380,7 +380,7 @@
  than EMIN, and @b 0 otherwise. \
 */
 
-#define doc_cpf_isfun(STRING, PMAX, EMAX) \
+#define doc_cpf_isfun(STRING, PMAX, EMAX, EMIN) \
 /** \
  @brief Check whether value is STRING in lower precision target format. \
  \

--- a/src/cpfloat_docmacros.h
+++ b/src/cpfloat_docmacros.h
@@ -4,7 +4,7 @@
 #ifndef _CPFLOAT_DOCMACROS_
 #define _CPFLOAT_DOCMACROS_
 
-#define doc_cpfloat_validate_optstruct(FPTYPE, PMIN, PMAX, EMAX, EMIN) \
+#define doc_cpfloat_validate_optstruct(FPTYPE, PMIN, PMAX, EMIN, EMAX) \
 /** \
  @brief Validate fields of @ref optstruct struct for `FPTYPE` storage format. \
  \
@@ -23,8 +23,6 @@
  Possible return values are: \
  \li @b -4 The rounding mode specified in @p fpopts->round does not correspond \
  to a valid choice, thus no rounding will be performed. \
- \li @b -3 The required minimum exponent in @p fpopts->emin is larger than \
- EMIN, the largest possible exponent for a variable of type `FPTYPE`.   \
  \li @b -2 The required number of digits in @p fpopts->precision is between \
  PMIN and PMAX inclusive, which might cause double rounding if round-to-\
  nearest is used. \
@@ -33,7 +31,9 @@
  \li @b  0 All the parameters in @p fpopts are valid. \
  \li @b  2 The required number of digits in @p fpopts->precision is larger \
  than PMAX, the number of significant digits in a variable of type `FPTYPE`. \
- \li @b  3 The required maximum exponent in @p fpopts->emax is larger than \
+ \li @b  3 The required minimum exponent in @p fpopts->emin is larger than \
+ EMIN, the largest possible exponent for a variable of type `FPTYPE`, or \
+ the required maximum exponent in @p fpopts->emax is larger than        \
  EMAX, the largest possible exponent for a variable of type `FPTYPE`. \
  \li @b  5 The value of @p fpopts->flip indicates that soft errors should be \
  introduced, but @p fpopts->p is not a real number between 0 and 1 and thus \
@@ -45,7 +45,7 @@
  given in the list above. \
  */
 
-#define doc_cpfloat(FPTYPE, PMAX, EMAX, EMIN) \
+#define doc_cpfloat(FPTYPE, PMAX, EMIN, EMAX) \
 /** \
  @brief Round `FPTYPE` array to lower precision. \
  \
@@ -65,11 +65,11 @@
  and the probability of soft errors striking the rounded values. \
  \
  @return The function returns @b 1 if @p fpopts->precision is larger than \
- PMAX, @b 2 if @p fpopts->emax is larger than EMAX or fptops->emin is smaller
- than EMIN, and @b 0 otherwise. \
+ PMAX, @b 2 if @p fptops->emin is smaller than EMIN or fpopts->emax is larger \
+ than EMAX, and @b 0 otherwise.                                    \
  */
 
-#define doc_cpf_univariate(MATHFUN, FUNSTRING, PMAX, EMAX, EMIN) \
+#define doc_cpf_univariate(MATHFUN, FUNSTRING, PMAX, EMIN, EMAX) \
 /** \
  @brief Compute MATHFUN rounded to lower precision. \
  \
@@ -89,11 +89,11 @@
  and the probability of soft errors striking the rounded values. \
  \
  @return The function returns @b 1 if @p fpopts->precision is larger than \
- PMAX, @b 2 if @p fpopts->emax is larger than EMAX or fptops->emin is smaller
- than EMIN, and @b 0 otherwise. \
+ PMAX, @b 2 if @p fptops->emin is smaller than EMIN or fpopts->emax is larger \
+ than EMAX, and @b 0 otherwise.                                    \
 */
 
-#define doc_cpf_univariate_nobitflip(MATHFUN, FUNSTRING, PMAX, EMAX, EMIN) \
+#define doc_cpf_univariate_nobitflip(MATHFUN, FUNSTRING, PMAX, EMIN, EMAX) \
 /** \
  @brief Compute MATHFUN in lower precision. \
  \
@@ -112,11 +112,11 @@
  and the probability of soft errors striking the rounded values. \
  \
  @return The function returns @b 1 if @p fpopts->precision is larger than \
- PMAX, @b 2 if @p fpopts->emax is larger than EMAX or fptops->emin is smaller
- than EMIN, and @b 0 otherwise. \
+ PMAX, @b 2 if @p fptops->emin is smaller than EMIN or fpopts->emax is larger \
+ than EMAX, and @b 0 otherwise.                                    \
 */
 
-#define doc_cpf_bivariate(MATHFUN, FUNSTRING, PMAX, EMAX, EMIN) \
+#define doc_cpf_bivariate(MATHFUN, FUNSTRING, PMAX, EMIN, EMAX) \
 /** \
  @brief Compute MATHFUN in lower precision. \
  \
@@ -137,11 +137,11 @@
  and the probability of soft errors striking the rounded values. \
  \
  @return The function returns @b 1 if @p fpopts->precision is larger than \
- PMAX, @b 2 if @p fpopts->emax is larger than EMAX or fptops->emin is smaller
- than EMIN, and @b 0 otherwise. \
+ PMAX, @b 2 if @p fptops->emin is smaller than EMIN or fpopts->emax is larger \
+ than EMAX, and @b 0 otherwise.                                    \
 */
 
-#define doc_cpf_trivariate(MATHFUN, FUNSTRING, PMAX, EMAX, EMIN) \
+#define doc_cpf_trivariate(MATHFUN, FUNSTRING, PMAX, EMIN, EMAX) \
 /** \
  @brief Compute MATHFUN in lower precision. \
  \
@@ -163,11 +163,11 @@
  and the probability of soft errors striking the rounded values. \
  \
  @return The function returns @b 1 if @p fpopts->precision is larger than \
- PMAX, @b 2 if @p fpopts->emax is larger than EMAX or fptops->emin is smaller
- than EMIN, and @b 0 otherwise. \
+ PMAX, @b 2 if @p fptops->emin is smaller than EMIN or fpopts->emax is larger \
+ than EMAX, and @b 0 otherwise.                                    \
 */
 
-#define doc_cpf_frexp(PMAX, EMAX, EMIN) \
+#define doc_cpf_frexp(PMAX, EMIN, EMAX) \
 /** \
  @brief Exponent and normalized fraction of rounded floating-point number. \
  \
@@ -195,11 +195,11 @@
  and the probability of soft errors striking the rounded values. \
  \
  @return The function returns @b 1 if @p fpopts->precision is larger than \
- PMAX, @b 2 if @p fpopts->emax is larger than EMAX or fptops->emin is smaller
- than EMIN, and @b 0 otherwise. \
+ PMAX, @b 2 if @p fptops->emin is smaller than EMIN or fpopts->emax is larger \
+ than EMAX, and @b 0 otherwise.                                    \
 */
 
-#define doc_cpf_scaling(BASE, PMAX, EMAX, EMIN) \
+#define doc_cpf_scaling(BASE, PMAX, EMIN, EMAX) \
 /** \
  @brief Scale number by power of BASE in lower precision. \
  \
@@ -220,11 +220,11 @@
  and the probability of soft errors striking the rounded values. \
  \
  @return The function returns @b 1 if @p fpopts->precision is larger than \
- PMAX, @b 2 if @p fpopts->emax is larger than EMAX or fptops->emin is smaller
- than EMIN, and @b 0 otherwise. \
+ PMAX, @b 2 if @p fptops->emin is smaller than EMIN or fpopts->emax is larger \
+ than EMAX, and @b 0 otherwise.                                    \
 */
 
-#define doc_cpf_modf(PMAX, EMAX, EMIN) \
+#define doc_cpf_modf(PMAX, EMIN, EMAX) \
 /** \
  @brief Compute integral and fractional part. \
  \
@@ -246,11 +246,11 @@
  and the probability of soft errors striking the rounded values. \
  \
  @return The function returns @b 1 if @p fpopts->precision is larger than \
- PMAX, @b 2 if @p fpopts->emax is larger than EMAX or fptops->emin is smaller
- than EMIN, and @b 0 otherwise. \
+ PMAX, @b 2 if @p fptops->emin is smaller than EMIN or fpopts->emax is larger \
+ than EMAX, and @b 0 otherwise.                                    \
 */
 
-#define doc_cpf_ilogb(PMAX, EMAX, EMIN) \
+#define doc_cpf_ilogb(PMAX, EMIN, EMAX) \
 /** \
  @brief Compute integral part of the logarithm of the absolute value. \
  \
@@ -271,11 +271,11 @@
  and the probability of soft errors striking the rounded values. \
  \
  @return The function returns @b 1 if @p fpopts->precision is larger than \
- PMAX, @b 2 if @p fpopts->emax is larger than EMAX or fptops->emin is smaller
- than EMIN, and @b 0 otherwise. \
+ PMAX, @b 2 if @p fptops->emin is smaller than EMIN or fpopts->emax is larger \
+ than EMAX, and @b 0 otherwise.                                    \
 */
 
-#define doc_cpf_rint(PMAX, EMAX, EMIN) \
+#define doc_cpf_rint(PMAX, EMIN, EMAX) \
 /** \
  @brief Compute the closest integer with specified rounding mode. \
  \
@@ -297,11 +297,11 @@
  and the probability of soft errors striking the rounded values. \
  \
  @return The function returns @b 1 if @p fpopts->precision is larger than \
- PMAX, @b 2 if @p fpopts->emax is larger than EMAX or fptops->emin is smaller
- than EMIN, and @b 0 otherwise. \
+ PMAX, @b 2 if @p fptops->emin is smaller than EMIN or fpopts->emax is larger \
+ than EMAX, and @b 0 otherwise.                                    \
 */
 
-#define doc_cpf_nearbyint(PMAX, EMAX, EMIN) \
+#define doc_cpf_nearbyint(PMAX, EMIN, EMAX) \
 /** \
  @brief Compute the closest integer with specified rounding mode. \
  \
@@ -321,12 +321,12 @@
  and the probability of soft errors striking the rounded values. \
  \
  @return The function returns @b 1 if @p fpopts->precision is larger than \
- PMAX, @b 2 if @p fpopts->emax is larger than EMAX or fptops->emin is smaller
- than EMIN, and @b 0 otherwise. \
+ PMAX, @b 2 if @p fptops->emin is smaller than EMIN or fpopts->emax is larger \
+ than EMAX, and @b 0 otherwise.                                    \
 */
 
 
-#define doc_cpf_remquo(PMAX, EMAX, EMIN) \
+#define doc_cpf_remquo(PMAX, EMIN, EMAX) \
 /** \
  @brief Compute reminder and quotient of rounded numbers. \
  \
@@ -349,11 +349,11 @@
  and the probability of soft errors striking the rounded values. \
  \
  @return The function returns @b 1 if @p fpopts->precision is larger than \
- PMAX, @b 2 if @p fpopts->emax is larger than EMAX or fptops->emin is smaller
- than EMIN, and @b 0 otherwise. \
+ PMAX, @b 2 if @p fptops->emin is smaller than EMIN or fpopts->emax is larger \
+ than EMAX, and @b 0 otherwise.                                    \
 */
 
-#define doc_cpf_fpclassify(PMAX, EMAX, EMIN) \
+#define doc_cpf_fpclassify(PMAX, EMIN, EMAX) \
 /** \
  @brief Categorize floating-point values. \
  \
@@ -376,11 +376,11 @@
  and the probability of soft errors striking the rounded values. \
  \
  @return The function returns @b 1 if @p fpopts->precision is larger than \
- PMAX, @b 2 if @p fpopts->emax is larger than EMAX or fptops->emin is smaller
- than EMIN, and @b 0 otherwise. \
+ PMAX, @b 2 if @p fptops->emin is smaller than EMIN or fpopts->emax is larger \
+ than EMAX, and @b 0 otherwise.                                    \
 */
 
-#define doc_cpf_isfun(STRING, PMAX, EMAX, EMIN) \
+#define doc_cpf_isfun(STRING, PMAX, EMIN, EMAX) \
 /** \
  @brief Check whether value is STRING in lower precision target format. \
  \
@@ -399,8 +399,8 @@
  and the probability of soft errors striking the rounded values. \
  \
  @return The function returns @b 1 if @p fpopts->precision is larger than \
- PMAX, @b 2 if @p fpopts->emax is larger than EMAX or fptops->emin is smaller
- than EMIN, and @b 0 otherwise. \
+ PMAX, @b 2 if @p fptops->emin is smaller than EMIN or fpopts->emax is larger \
+ than EMAX, and @b 0 otherwise.                                    \
 */
 
 #endif  /* #ifndef _CPFLOAT_DOCMACROS_ */

--- a/src/cpfloat_docmacros.h
+++ b/src/cpfloat_docmacros.h
@@ -4,7 +4,7 @@
 #ifndef _CPFLOAT_DOCMACROS_
 #define _CPFLOAT_DOCMACROS_
 
-#define doc_cpfloat_validate_optstruct(FPTYPE, PMIN, PMAX, EMAX) \
+#define doc_cpfloat_validate_optstruct(FPTYPE, PMIN, PMAX, EMAX, EMIN) \
 /** \
  @brief Validate fields of @ref optstruct struct for `FPTYPE` storage format. \
  \
@@ -23,6 +23,8 @@
  Possible return values are: \
  \li @b -4 The rounding mode specified in @p fpopts->round does not correspond \
  to a valid choice, thus no rounding will be performed. \
+ \li @b -3 The required minimum exponent in @p fpopts->emin is larger than \
+ EMIN, the largest possible exponent for a variable of type `FPTYPE`.   \
  \li @b -2 The required number of digits in @p fpopts->precision is between \
  PMIN and PMAX inclusive, which might cause double rounding if round-to-\
  nearest is used. \
@@ -63,7 +65,8 @@
  and the probability of soft errors striking the rounded values. \
  \
  @return The function returns @b 1 if @p fpopts->precision is larger than \
- PMAX, @b 2 if @p fpopts->emax is larger than EMAX, and @b 0 otherwise. \
+ PMAX, @b 2 if @p fpopts->emax is larger than EMAX or fptops->emin is smaller
+ than EMIN, and @b 0 otherwise. \
  */
 
 #define doc_cpf_univariate(MATHFUN, FUNSTRING, PMAX, EMAX) \
@@ -86,7 +89,8 @@
  and the probability of soft errors striking the rounded values. \
  \
  @return The function returns @b 1 if @p fpopts->precision is larger than \
- PMAX, @b 2 if @p fpopts->emax is larger than EMAX, and @b 0 otherwise. \
+ PMAX, @b 2 if @p fpopts->emax is larger than EMAX or fptops->emin is smaller
+ than EMIN, and @b 0 otherwise. \
 */
 
 #define doc_cpf_univariate_nobitflip(MATHFUN, FUNSTRING, PMAX, EMAX) \
@@ -108,7 +112,8 @@
  and the probability of soft errors striking the rounded values. \
  \
  @return The function returns @b 1 if @p fpopts->precision is larger than \
- PMAX, @b 2 if @p fpopts->emax is larger than EMAX, and @b 0 otherwise. \
+ PMAX, @b 2 if @p fpopts->emax is larger than EMAX or fptops->emin is smaller
+ than EMIN, and @b 0 otherwise. \
 */
 
 #define doc_cpf_bivariate(MATHFUN, FUNSTRING, PMAX, EMAX) \
@@ -132,7 +137,8 @@
  and the probability of soft errors striking the rounded values. \
  \
  @return The function returns @b 1 if @p fpopts->precision is larger than \
- PMAX, @b 2 if @p fpopts->emax is larger than EMAX, and @b 0 otherwise. \
+ PMAX, @b 2 if @p fpopts->emax is larger than EMAX or fptops->emin is smaller
+ than EMIN, and @b 0 otherwise. \
 */
 
 #define doc_cpf_trivariate(MATHFUN, FUNSTRING, PMAX, EMAX) \
@@ -157,7 +163,8 @@
  and the probability of soft errors striking the rounded values. \
  \
  @return The function returns @b 1 if @p fpopts->precision is larger than \
- PMAX, @b 2 if @p fpopts->emax is larger than EMAX, and @b 0 otherwise. \
+ PMAX, @b 2 if @p fpopts->emax is larger than EMAX or fptops->emin is smaller
+ than EMIN, and @b 0 otherwise. \
 */
 
 #define doc_cpf_frexp(PMAX, EMAX) \
@@ -188,7 +195,8 @@
  and the probability of soft errors striking the rounded values. \
  \
  @return The function returns @b 1 if @p fpopts->precision is larger than \
- PMAX, @b 2 if @p fpopts->emax is larger than EMAX, and @b 0 otherwise. \
+ PMAX, @b 2 if @p fpopts->emax is larger than EMAX or fptops->emin is smaller
+ than EMIN, and @b 0 otherwise. \
 */
 
 #define doc_cpf_scaling(BASE, PMAX, EMAX) \
@@ -212,7 +220,8 @@
  and the probability of soft errors striking the rounded values. \
  \
  @return The function returns @b 1 if @p fpopts->precision is larger than \
- PMAX, @b 2 if @p fpopts->emax is larger than EMAX, and @b 0 otherwise. \
+ PMAX, @b 2 if @p fpopts->emax is larger than EMAX or fptops->emin is smaller
+ than EMIN, and @b 0 otherwise. \
 */
 
 #define doc_cpf_modf(PMAX, EMAX) \
@@ -237,7 +246,8 @@
  and the probability of soft errors striking the rounded values. \
  \
  @return The function returns @b 1 if @p fpopts->precision is larger than \
- PMAX, @b 2 if @p fpopts->emax is larger than EMAX, and @b 0 otherwise. \
+ PMAX, @b 2 if @p fpopts->emax is larger than EMAX or fptops->emin is smaller
+ than EMIN, and @b 0 otherwise. \
 */
 
 #define doc_cpf_ilogb(PMAX, EMAX) \
@@ -261,7 +271,8 @@
  and the probability of soft errors striking the rounded values. \
  \
  @return The function returns @b 1 if @p fpopts->precision is larger than \
- PMAX, @b 2 if @p fpopts->emax is larger than EMAX, and @b 0 otherwise. \
+ PMAX, @b 2 if @p fpopts->emax is larger than EMAX or fptops->emin is smaller
+ than EMIN, and @b 0 otherwise. \
 */
 
 #define doc_cpf_rint(PMAX, EMAX) \
@@ -286,7 +297,8 @@
  and the probability of soft errors striking the rounded values. \
  \
  @return The function returns @b 1 if @p fpopts->precision is larger than \
- PMAX, @b 2 if @p fpopts->emax is larger than EMAX, and @b 0 otherwise. \
+ PMAX, @b 2 if @p fpopts->emax is larger than EMAX or fptops->emin is smaller
+ than EMIN, and @b 0 otherwise. \
 */
 
 #define doc_cpf_nearbyint(PMAX, EMAX) \
@@ -309,7 +321,8 @@
  and the probability of soft errors striking the rounded values. \
  \
  @return The function returns @b 1 if @p fpopts->precision is larger than \
- PMAX, @b 2 if @p fpopts->emax is larger than EMAX, and @b 0 otherwise. \
+ PMAX, @b 2 if @p fpopts->emax is larger than EMAX or fptops->emin is smaller
+ than EMIN, and @b 0 otherwise. \
 */
 
 
@@ -336,7 +349,8 @@
  and the probability of soft errors striking the rounded values. \
  \
  @return The function returns @b 1 if @p fpopts->precision is larger than \
- PMAX, @b 2 if @p fpopts->emax is larger than EMAX, and @b 0 otherwise. \
+ PMAX, @b 2 if @p fpopts->emax is larger than EMAX or fptops->emin is smaller
+ than EMIN, and @b 0 otherwise. \
 */
 
 #define doc_cpf_fpclassify(PMAX, EMAX) \
@@ -362,7 +376,8 @@
  and the probability of soft errors striking the rounded values. \
  \
  @return The function returns @b 1 if @p fpopts->precision is larger than \
- PMAX, @b 2 if @p fpopts->emax is larger than EMAX, and @b 0 otherwise. \
+ PMAX, @b 2 if @p fpopts->emax is larger than EMAX or fptops->emin is smaller
+ than EMIN, and @b 0 otherwise. \
 */
 
 #define doc_cpf_isfun(STRING, PMAX, EMAX) \
@@ -384,7 +399,8 @@
  and the probability of soft errors striking the rounded values. \
  \
  @return The function returns @b 1 if @p fpopts->precision is larger than \
- PMAX, @b 2 if @p fpopts->emax is larger than EMAX, and @b 0 otherwise. \
+ PMAX, @b 2 if @p fpopts->emax is larger than EMAX or fptops->emin is smaller
+ than EMIN, and @b 0 otherwise. \
 */
 
 #endif  /* #ifndef _CPFLOAT_DOCMACROS_ */

--- a/src/cpfloat_template.h
+++ b/src/cpfloat_template.h
@@ -295,7 +295,9 @@ static inline FPPARAMS COMPUTE_GLOBAL_PARAMS(const optstruct *fpopts,
   cpfloat_exponent_t emax = fpopts->explim == CPFLOAT_EXPRANGE_TARG ?
     fpopts->emax :
     DEFEMAX;
-  cpfloat_exponent_t emin = fpopts->emin;
+  cpfloat_exponent_t emin = fpopts->explim == CPFLOAT_EXPRANGE_TARG ?
+    fpopts->emin :
+    DEFEMIN;
 
   if (precision > DEFPREC) {
     precision = DEFPREC;

--- a/src/cpfloat_template.h
+++ b/src/cpfloat_template.h
@@ -106,7 +106,7 @@ optstruct *init_optstruct() {
   fpopts->bitseed = NULL;
   fpopts->randseedf = NULL;
   fpopts->randseed = NULL;
-  fpopts->emin = -99999;
+  fpopts->emin = 0;
   return fpopts;
 }
 
@@ -283,7 +283,7 @@ static inline int VALIDATE_INPUT(const optstruct *fpopts) {
   /* Return -6 if emin is invalid (either nonnegative or too small). */
   if (fpopts->emin < DEFEMIN || fpopts->emin >= 0)
     return -6;
-  
+
   /* Return 0 or warning value. */
   return retval;
 }
@@ -310,8 +310,8 @@ static inline FPPARAMS COMPUTE_GLOBAL_PARAMS(const optstruct *fpopts,
 
   /* Derived floating point parameters. */
   int emin = fpopts->emin;
-  /* If emin is not set by user, set it to the default 1-emax. */
-  if (emin == -99999)
+  /* If emin is not set by the user, set it to the default 1-emax. */
+  if (emin == 0)
     emin = 1-emax;
   if (emin < DEFEMIN) {
     emax = DEFEMIN;

--- a/src/cpfloat_template.h
+++ b/src/cpfloat_template.h
@@ -1211,7 +1211,7 @@ GENERATE_UNIVARIATE_MATH_H(lgamma, lgamma)
    if (temp == FP_ILOGB0 || temp == FP_ILOGBNAN || temp == INT_MAX) {          \
      params.precision = DEFPREC-1;                                             \
      params.emax = DEFEMAX;                                                    \
-     params.emax = DEFEMIN;                                                    \
+     params.emin = DEFEMIN;                                                    \
    } else {                                                                    \
      params.precision = temp + 1;                                              \
      params.ftzthreshold = 1.0;                                                \

--- a/src/cpfloat_template.h
+++ b/src/cpfloat_template.h
@@ -106,7 +106,6 @@ optstruct *init_optstruct() {
   fpopts->bitseed = NULL;
   fpopts->randseedf = NULL;
   fpopts->randseed = NULL;
-  fpopts->emin = 0;
   return fpopts;
 }
 

--- a/test/cpfloat_test.m
+++ b/test/cpfloat_test.m
@@ -193,6 +193,10 @@ function cpfloat_test
       % Modification for OCP compliant q43.
       emax = 8; % Previously thought to be 7
       emin = -6; % Previously thought to be 1-emax=-7.
+      emins = emin + 1 - p; % Exponent of smallest subnormal number.
+      xmins = 2^emins;
+      xmin = 2^emin;
+      xmax = 2^emax * (2-2^(1-p));
     elseif i == 4
       % Quarter precision tests.
       [u,xmins,xmin,xmax,p,emins,emin,emax] = float_params('q52');

--- a/test/cpfloat_test.m
+++ b/test/cpfloat_test.m
@@ -94,21 +94,21 @@ function cpfloat_test
   [c,options] = cpfloat(pi,fp);
   assert_eq(options.format,'d')
   assert_eq(options.subnormal,1)
-  assert_eq(options.params, [53 1023 -1022])
+  assert_eq(options.params, [53 -1022 1023])
   [~,fp] = cpfloat;
   assert_eq(fp.format,'d')
   assert_eq(fp.subnormal,1)
-  assert_eq(fp.params, [53 1023 -1022])
+  assert_eq(fp.params, [53 -1022 1023])
 
   clear fp
   fp.format = 'bfloat16'; [c,options] = cpfloat(pi,fp);
   assert_eq(options.format,'bfloat16')
   assert_eq(options.subnormal,0)
-  assert_eq(options.params, [8 127 -126])
+  assert_eq(options.params, [8 -126 127])
   [~,fp] = cpfloat;
   assert_eq(fp.format,'bfloat16')
   assert_eq(fp.subnormal,0)
-  assert_eq(fp.params, [8 127 -126])
+  assert_eq(fp.params, [8 -126 127])
 
   clear cpfloat
   [~,fp] = cpfloat;
@@ -137,7 +137,7 @@ function cpfloat_test
   A2 = hilb(6); C = cpfloat(A2);
 
   options.format = 'c';
-  options.params = [8 127 -126];  % bfloat16
+  options.params = [8 -126 127];  % bfloat16
   C1 = cpfloat(A,options);
   assert_eq(A,C1);
   C2 = cpfloat(B,options);
@@ -146,7 +146,7 @@ function cpfloat_test
 
   clear options
   options.format = 'c';
-  options.params = [11 15 -14];  % h
+  options.params = [11 -14 15];  % h
   options2.format = 'h';
   A = hilb(6);
   [X1,opt] = cpfloat(A,options);
@@ -191,8 +191,8 @@ function cpfloat_test
       [u,xmins,xmin,xmax,p,emins,emin,emax] = float_params('q43');
       options.format = 'E4M3';
       % Modification for OCP compliant q43.
-      emax = 8; % Previously thought to be 7
       emin = -6; % Previously thought to be 1-emax=-7.
+      emax = 8; % Previously thought to be 7
       emins = emin + 1 - p; % Exponent of smallest subnormal number.
       xmins = 2^emins;
       xmin = 2^emin;
@@ -571,7 +571,7 @@ function cpfloat_test
   assert_eq(cd,double(cs));
 
   options.format = 'c';
-  options.params = [11 5 -4];
+  options.params = [11 -4 5];
   temp1 = cpfloat(single(pi),options);
   options.format = 'h';
   options = rmfield(options, 'params');
@@ -602,14 +602,14 @@ function cpfloat_test
   temp = 0;
   try
     options.format = 'c';
-    options.params = [12 5 -4];
+    options.params = [12 -4 5];
     temp = cpfloat(single(pi),options); % Error - double rounding!
   catch
   end
   assert_eq(temp,0)
   try
     options.format = 'c';
-    options.params = [26 9 -8];
+    options.params = [26 -8 9];
     temp = cpfloat(pi,options); % Error - double rounding!
   catch
   end

--- a/test/cpfloat_test.m
+++ b/test/cpfloat_test.m
@@ -190,6 +190,9 @@ function cpfloat_test
       % Quarter precision tests.
       [u,xmins,xmin,xmax,p,emins,emin,emax] = float_params('q43');
       options.format = 'E4M3';
+      % Modification for OCP compliant q43.
+      emax = 8; % Previously thought to be 7
+      emin = -6; % Previously thought to be 1-emax=-7.
     elseif i == 4
       % Quarter precision tests.
       [u,xmins,xmin,xmax,p,emins,emin,emax] = float_params('q52');

--- a/test/cpfloat_test.m
+++ b/test/cpfloat_test.m
@@ -94,21 +94,21 @@ function cpfloat_test
   [c,options] = cpfloat(pi,fp);
   assert_eq(options.format,'d')
   assert_eq(options.subnormal,1)
-  assert_eq(options.params, [53 1023])
+  assert_eq(options.params, [53 1023 -1022])
   [~,fp] = cpfloat;
   assert_eq(fp.format,'d')
   assert_eq(fp.subnormal,1)
-  assert_eq(fp.params, [53 1023])
+  assert_eq(fp.params, [53 1023 -1022])
 
   clear fp
   fp.format = 'bfloat16'; [c,options] = cpfloat(pi,fp);
   assert_eq(options.format,'bfloat16')
   assert_eq(options.subnormal,0)
-  assert_eq(options.params, [8 127])
+  assert_eq(options.params, [8 127 -126])
   [~,fp] = cpfloat;
   assert_eq(fp.format,'bfloat16')
   assert_eq(fp.subnormal,0)
-  assert_eq(fp.params, [8 127])
+  assert_eq(fp.params, [8 127 -126])
 
   clear cpfloat
   [~,fp] = cpfloat;
@@ -137,7 +137,7 @@ function cpfloat_test
   A2 = hilb(6); C = cpfloat(A2);
 
   options.format = 'c';
-  options.params = [8 127];  % bfloat16
+  options.params = [8 127 -126];  % bfloat16
   C1 = cpfloat(A,options);
   assert_eq(A,C1);
   C2 = cpfloat(B,options);
@@ -146,7 +146,7 @@ function cpfloat_test
 
   clear options
   options.format = 'c';
-  options.params = [11 15];  % h
+  options.params = [11 15 -14];  % h
   options2.format = 'h';
   A = hilb(6);
   [X1,opt] = cpfloat(A,options);
@@ -571,7 +571,7 @@ function cpfloat_test
   assert_eq(cd,double(cs));
 
   options.format = 'c';
-  options.params = [11 5];
+  options.params = [11 5 -4];
   temp1 = cpfloat(single(pi),options);
   options.format = 'h';
   options = rmfield(options, 'params');
@@ -602,14 +602,14 @@ function cpfloat_test
   temp = 0;
   try
     options.format = 'c';
-    options.params = [12 5];
+    options.params = [12 5 -4];
     temp = cpfloat(single(pi),options); % Error - double rounding!
   catch
   end
   assert_eq(temp,0)
   try
     options.format = 'c';
-    options.params = [26 9];
+    options.params = [26 9 -8];
     temp = cpfloat(pi,options); % Error - double rounding!
   catch
   end

--- a/test/cpfloat_test.ts
+++ b/test/cpfloat_test.ts
@@ -45,6 +45,7 @@ typedef union {
 // binary16, bfloat16, TensorFloat-32
 static size_t precision [] = {11, 8, 11};
 static size_t emax [] = {15, 127, 127};
+static size_t emin [] = {-14, -126, -126};
 static size_t nformats = 2;
 
 /* Structure for options and fixtures. */
@@ -592,7 +593,7 @@ void select_tests_det_double(double *y, double *x, double *ref,
     fpopts->round = round;
     for (format = minformat; format <= maxformat; format++) {
       fpopts->precision = precision[format];
-      fpopts->emax = emax[format];
+      fpopts->emax = emax[format]; fpopts->emin = emin[format];
       for (subnormal = minsubnormal; subnormal <= maxsubnormal; subnormal++) {
         fpopts->subnormal = subnormal;
         for (explim = minexplim; explim <= maxexplim; explim++) {
@@ -624,7 +625,7 @@ void select_tests_det_float(float *y, float *x, float *ref,
     fpopts->round = round;
     for (format = minformat; format <= maxformat; format++) {
       fpopts->precision = precision[format];
-      fpopts->emax = emax[format];
+      fpopts->emax = emax[format]; fpopts->emin = emin[format];
       for (subnormal = minsubnormal; subnormal <= maxsubnormal; subnormal++) {
         fpopts->subnormal = subnormal;
         for (explim = minexplim; explim <= maxexplim; explim++) {
@@ -656,7 +657,7 @@ void select_tests_stoc_double(double *tmpin, double *tmpout,
   fpopts->round = mode;
   for (format = minformat; format <= maxformat; format++) {
     fpopts->precision = precision[format];
-    fpopts->emax = emax[format];
+    fpopts->emax = emax[format]; fpopts->emin = emin[format];
     for (subnormal = minsubnormal; subnormal <= maxsubnormal; subnormal++) {
       fpopts->subnormal = subnormal;
       for (explim = minexplim; explim <= maxexplim; explim++) {
@@ -691,7 +692,7 @@ void select_tests_stoc_float(float *tmpin, float *tmpout,
   fpopts->round = mode;
   for (format = minformat; format <= maxformat; format++) {
     fpopts->precision = precision[format];
-    fpopts->emax = emax[format];
+    fpopts->emax = emax[format]; fpopts->emin = emin[format];
     for (subnormal = minsubnormal; subnormal <= maxsubnormal; subnormal++) {
       fpopts->subnormal = subnormal;
       for (explim = minexplim; explim <= maxexplim; explim++) {
@@ -926,7 +927,7 @@ printf("1b. No rounding: subnormal numbers\n");
 for (size_t mode=1; mode<3; mode++) {
   for (size_t i = 0; i < nformats; i++) {
     fpopts->precision = precision[i];
-    fpopts->emax = emax[i];
+    fpopts->emax = emax[i]; fpopts->emin = emin[i];
     size_t n = ldexp(1.,fpopts->precision-1) - 1; // number of subnormals
     double *xd = malloc(n * sizeof(*xd));
     init_fparray_double(xd, n, minsubnormal(fpopts), minsubnormal(fpopts));
@@ -964,7 +965,7 @@ printf("1c. No rounding: normal numbers\n");
 for (size_t mode=1; mode<3; mode++) {
   for (size_t i = 0; i < nformats; i++) {
     fpopts->precision = precision[i];
-    fpopts->emax = emax[i];
+    fpopts->emax = emax[i]; fpopts->emin = emin[i];
     size_t n = ldexp(1., fpopts->precision-1) * 2 * fpopts->emax;
     uint64_t *xd = malloc(n * sizeof(*xd));
     init_intarray_double(xd, n, intminnormal_double(fpopts),
@@ -1018,7 +1019,7 @@ for (size_t mode=1; mode<3; mode++) {
   float *yf = allocate_array_float(xf, n, mode);
   for (size_t i = 0; i < nformats; i++) {
     fpopts->precision = precision[i];
-    fpopts->emax = emax[i];
+    fpopts->emax = emax[i]; fpopts->emin = emin[i];
     double xmin = minnormal(fpopts);
     double snxmin = minsubnormal(fpopts);
     double halfxmin = xmin / 2;
@@ -1168,7 +1169,7 @@ for (size_t mode=1; mode<3; mode++) {
   float *yf = allocate_array_float(xf, n, mode);
   for (size_t i = 0; i < nformats; i++) {
     fpopts->precision = precision[i];
-    fpopts->emax = emax[i];
+    fpopts->emax = emax[i]; fpopts->emin = emin[i];
     double xmin = minsubnormal(fpopts);
     double halfxmin = xmin / 2;
     double xd_imm [] = {nextafter(0, INFINITY),
@@ -1312,7 +1313,7 @@ for (size_t mode=1; mode<3; mode++) {
   float *yf = allocate_array_float(xf, n, mode);
   for (size_t i = 0; i < nformats; i++) {
     fpopts->precision = precision[i];
-    fpopts->emax = emax[i];
+    fpopts->emax = emax[i]; fpopts->emin = emin[i];
     double xmax = maxnormal(fpopts);
     double xbound = maxbound(fpopts);
     double xd_imm [] = {nextafter(xmax, INFINITY),
@@ -1445,7 +1446,7 @@ printf("2d. Deterministic rounding: subnormal numbers\n");
 for (size_t mode=1; mode<3; mode++) {
   for (size_t i = 0; i < nformats; i++) {
     fpopts->precision = precision[i];
-    fpopts->emax = emax[i];
+    fpopts->emax = emax[i]; fpopts->emin = emin[i];
     size_t n = 3 * ldexp(1.,fpopts->precision-1) - 1;
     double *xd_imm = malloc(n * sizeof(*xd_imm));
     double *xd = malloc(n * sizeof(*xd));
@@ -1657,7 +1658,7 @@ printf("2e. Deterministic rounding: normal numbers\n");
 for (size_t mode=1; mode<3; mode++) {
   for (size_t i = 0; i < nformats; i++) {
     fpopts->precision = precision[i];
-    fpopts->emax = emax[i];
+    fpopts->emax = emax[i]; fpopts->emin = emin[i];
     size_t n = 3 * (ldexp(1., fpopts->precision-1) * 2 * fpopts->emax - 1);
     uint64_t *xd_imm = malloc(n * sizeof(*xd_imm));
     uint64_t *refd = malloc(n * sizeof(*refd));
@@ -1881,7 +1882,7 @@ for (size_t mode=1; mode<3; mode++) {
   for(subnormal = 0; subnormal <= 1; subnormal++) {
     for(size_t i = 0; i < nformats; i++) {
       fpopts->precision = precision[i];
-      fpopts->emax = emax[i];
+      fpopts->emax = emax[i]; fpopts->emin = emin[i];
       double xmin;
       if (subnormal)
         xmin = minsubnormal(fpopts);
@@ -1932,7 +1933,7 @@ for (size_t mode=1; mode<3; mode++ ) {
   for(subnormal = 0; subnormal <= 1; subnormal++) {
     for(i = 0; i < nformats; i++) {
       fpopts->precision = precision[i];
-      fpopts->emax = emax[i];
+      fpopts->emax = emax[i]; fpopts->emin = emin[i];
       double xmax = maxnormal(fpopts);
       double xbound = maxbound(fpopts);
       double *yd =  malloc(n * sizeof(*yd));
@@ -2011,7 +2012,7 @@ double proundequi = 0.50;
 for (size_t mode=1; mode<3; mode++ ) {
   for (size_t i = 0; i < nformats; i++) {
     fpopts->precision = precision[i];
-    fpopts->emax = emax[i];
+    fpopts->emax = emax[i]; fpopts->emin = emin[i];
     size_t n = 3 * ldexp(1.,fpopts->precision-1) - 1;
     double *xd = malloc(n * sizeof(*xd));
     double stepd = minsubnormal(fpopts);
@@ -2065,7 +2066,7 @@ for (size_t mode=1; mode<3; mode++ ) {
     for (explim = 0; explim <= 1; explim++) {
       for (size_t i = 0; i < nformats; i++) {
         fpopts->precision = precision[i];
-        fpopts->emax = emax[i];
+        fpopts->emax = emax[i]; fpopts->emin = emin[i];
 
         size_t n = 3 * (ldexp(1., fpopts->precision-1) * 2 * fpopts->emax - 1);
         uint64_t *xd = malloc(n * sizeof(*xd));
@@ -2138,7 +2139,7 @@ size_t n_roundings = 7;
 
 for (size_t i = 0; i < nformats; i++) {
   fpopts->precision = precision[i];
-  fpopts->emax = emax[i];
+  fpopts->emax = emax[i]; fpopts->emin = emin[i];
   for (size_t i = 0; i < n_roundings; i++) {
     fpopts->round = det_roundings[i];
 
@@ -2271,7 +2272,7 @@ float *reff = malloc(n * sizeof(* xf));
 
 for (size_t i = 0; i < nformats; i++) {
   fpopts->precision = precision[i];
-  fpopts->emax = emax[i];
+  fpopts->emax = emax[i]; fpopts->emin = emin[i];
   for (size_t i = 0; i < n_roundings; i++) {
     fpopts->round = det_roundings[i];
     // Univariate functions.
@@ -2412,7 +2413,7 @@ const int resd_fpclassify [] = {FP_NORMAL, FP_NORMAL,FP_NORMAL, FP_SUBNORMAL,
 
 for (size_t i = 0; i < nformats; i++) {
   fpopts->precision = precision[i];
-  fpopts->emax = emax[i];
+  fpopts->emax = emax[i]; fpopts->emin = emin[i];
   double xmind = minnormal(fpopts);
   double xminds = minsubnormal(fpopts);
   double ad[] = {-2., -1, -xmind, -xminds, xminds, xmind, 1., CONST_SQRT2,
@@ -2504,7 +2505,7 @@ const int resf_fpclassify [] = {FP_NORMAL, FP_NORMAL,FP_NORMAL,
 
 for (size_t i = 0; i < nformats; i++) {
   fpopts->precision = precision[i];
-  fpopts->emax = emax[i];
+  fpopts->emax = emax[i]; fpopts->emin = emin[i];
   float xminf = minnormal(fpopts);
   float xminfs = minsubnormal(fpopts);
   float af[] = { -2., -1, -xminf, xminf, 1., CONST_SQRT2,
@@ -2590,7 +2591,7 @@ fpopts->subnormal = CPFLOAT_SUBN_USE;
 for (size_t mode=2; mode<3; mode++) {
   for (size_t i = 0; i < nformats; i++) {
     fpopts->precision = precision[i];
-    fpopts->emax = emax[i];
+    fpopts->emax = emax[i]; fpopts->emin = emin[i];
 
     size_t n = (ldexp(1.,fpopts->precision-1) - 1) + 2;
     double *ad = malloc(n * sizeof(*ad));
@@ -2690,7 +2691,7 @@ for (size_t mode=2; mode<3; mode++) {
 for (size_t mode=2; mode<3; mode++) {
   for (size_t i = 0; i < nformats; i++) {
     fpopts->precision = precision[i];
-    fpopts->emax = emax[i];
+    fpopts->emax = emax[i]; fpopts->emin = emin[i];
 
     size_t n = ldexp(1., fpopts->precision-1) * 2 * fpopts->emax + 2;
     double *ad = malloc(n * sizeof(*ad));
@@ -2798,6 +2799,7 @@ for (size_t mode=2; mode<3; mode++) {
 printf("4c. Integer rounding\n");
 
 fpopts->emax = emax[1];
+fpopts->emin = emin[1];
 fpopts->precision = precision[1];
 
 size_t n = 32;
@@ -2970,7 +2972,7 @@ check_equality_double_long_long(rd7, xll, n-3);
 printf("4d. Arithmetic operations on large arrays\n");
 size_t i = 0;
 fpopts->precision = precision[i];
-fpopts->emax = emax[i];
+fpopts->emax = emax[i]; fpopts->emin = emin[i];
 size_t n = 3 * (ldexp(1., fpopts->precision-1) * (ldexp(1., 5) - 2) - 1) - 2;
 double *ad = malloc(n * sizeof(*ad));
 double *bd = malloc(n * sizeof(*bd));

--- a/test/cpfloat_test.ts
+++ b/test/cpfloat_test.ts
@@ -73,40 +73,40 @@ void fpopts_teardown(void) {
 /* Return values of interest */
 static inline
 double minsubnormal(optstruct *fpopts) {
-  return ldexp(1., 2 - fpopts->emax - fpopts->precision);
+  return ldexp(1., fpopts->emin - fpopts->precision + 1);
 }
 
 static inline
 double maxsubnormal(optstruct *fpopts) {
-  return ldexp(1., 1 - fpopts->emax) *
+  return ldexp(1., fpopts->emin) *
     (1 - ldexp(1., 1 - fpopts->precision));
 }
 
 static inline
 uint64_t intmaxsubnormal_double(optstruct *fpopts) {
-  return INTOFd(ldexp(1., 1 - fpopts->emax) *
+  return INTOFd(ldexp(1., fpopts->emin) *
                (1 - ldexp(1., 1 - fpopts->precision)));
 }
 
 static inline
 uint32_t intmaxsubnormal_float(optstruct *fpopts) {
-  return INTOFf(ldexp(1., 1 - fpopts->emax) *
+  return INTOFf(ldexp(1., fpopts->emin) *
                (1 - ldexp(1., 1 - fpopts->precision)));
 }
 
 static inline
 double minnormal(optstruct *fpopts) {
-  return ldexp(1., 1-fpopts->emax);
+  return ldexp(1., fpopts->emin);
 }
 
 static inline
 uint64_t intminnormal_double(optstruct *fpopts) {
-  return INTOFd(ldexp(1., 1-fpopts->emax));
+  return INTOFd(ldexp(1., fpopts->emin));
 }
 
 static inline
 uint32_t intminnormal_float(optstruct *fpopts) {
-  return INTOFf(ldexp(1., 1-fpopts->emax));
+  return INTOFf(ldexp(1., fpopts->emin));
 }
 
 static inline


### PR DESCRIPTION
At present a test in ctest is failing, while matlab/octave tests pass.